### PR TITLE
Revert Mustache back to 0.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
             'com.google.code.gson:gson:2.3.1',
             'org.simpleframework:simple-xml:2.7.1',
             'com.google.guava:guava:18.0',
-            'com.github.spullara.mustache.java:compiler:0.9.0',
+            'com.github.spullara.mustache.java:compiler:0.8.0',
             'org.slf4j:slf4j-log4j12:1.7.12',
             'com.madgag:animated-gif-lib:1.2',
             'org.apache.commons:commons-lang3:3.4',


### PR DESCRIPTION
Current version 0.9 requires Java 8 as mentioned here:
https://github.com/spullara/mustache.java/issues/124

(Note, just created this PR via github as I don't have the source checked-out. Travis should verify the build).