### PR TITLE
Code quality fix -  Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.

### DIFF
--- a/fork-runner/src/main/java/org/jf/dexlib/DexFile.java
+++ b/fork-runner/src/main/java/org/jf/dexlib/DexFile.java
@@ -370,7 +370,7 @@ public class DexFile
             } else if (isDex) {
                 in = new ByteArrayInput(FileUtils.readStream(inputStream, (int)fileLength));
             } else {
-                StringBuffer sb = new StringBuffer("bad magic value:");
+                StringBuilder sb = new StringBuilder("bad magic value:");
                 for (int i=0; i<8; i++) {
                     sb.append(" ");
                     sb.append(Hex.u1(magic[i]));

--- a/fork-runner/src/main/java/org/jf/dexlib/FieldIdItem.java
+++ b/fork-runner/src/main/java/org/jf/dexlib/FieldIdItem.java
@@ -191,7 +191,7 @@ public class FieldIdItem extends Item<FieldIdItem> implements Convertible<FieldI
             String fieldName = this.fieldName.getStringValue();
             String fieldType = this.fieldType.getTypeDescriptor();
 
-            StringBuffer sb = new StringBuffer(typeDescriptor.length() + fieldName.length() + fieldType.length() + 3);
+            StringBuilder sb = new StringBuilder(typeDescriptor.length() + fieldName.length() + fieldType.length() + 3);
             sb.append(typeDescriptor);
             sb.append("->");
             sb.append(fieldName);
@@ -211,7 +211,7 @@ public class FieldIdItem extends Item<FieldIdItem> implements Convertible<FieldI
             String fieldName = this.fieldName.getStringValue();
             String fieldType = this.fieldType.getTypeDescriptor();
 
-            StringBuffer sb = new StringBuffer(fieldName.length() + fieldType.length() + 1);
+            StringBuilder sb = new StringBuilder(fieldName.length() + fieldType.length() + 1);
             sb.append(fieldName);
             sb.append(":");
             sb.append(fieldType);

--- a/fork-runner/src/main/java/org/jf/dexlib/Util/ExceptionWithContext.java
+++ b/fork-runner/src/main/java/org/jf/dexlib/Util/ExceptionWithContext.java
@@ -33,7 +33,7 @@ import java.io.PrintWriter;
 public class ExceptionWithContext
         extends RuntimeException {
     /** non-null; human-oriented context of the exception */
-    private StringBuffer context;
+    private StringBuilder context;
 
     /**
      * Augments the given exception with the given context, and return the
@@ -89,10 +89,10 @@ public class ExceptionWithContext
 
         if (cause instanceof ExceptionWithContext) {
             String ctx = ((ExceptionWithContext) cause).context.toString();
-            context = new StringBuffer(ctx.length() + 200);
+            context = new StringBuilder(ctx.length() + 200);
             context.append(ctx);
         } else {
-            context = new StringBuffer(200);
+            context = new StringBuilder(200);
         }
     }
 

--- a/fork-runner/src/main/java/org/jf/dexlib/Util/Hex.java
+++ b/fork-runner/src/main/java/org/jf/dexlib/Util/Hex.java
@@ -277,7 +277,7 @@ public final class Hex {
             return "";
         }
 
-        StringBuffer sb = new StringBuffer(length * 4 + 6);
+        StringBuilder sb = new StringBuilder(length * 4 + 6);
         boolean bol = true;
         int col = 0;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149

Please let me know if you have any questions.

Faisal Hameed