### PR TITLE
Code quality fix -  Declarations should use Java collection interfaces such as "List".

### DIFF
--- a/fork-common/src/main/java/com/shazam/fork/summary/Summary.java
+++ b/fork-common/src/main/java/com/shazam/fork/summary/Summary.java
@@ -39,11 +39,11 @@ public class Summary {
     }
 
     @Nonnull
-    public ArrayList<String> getIgnoredTests() {
+    public List<String> getIgnoredTests() {
         return ignoredTests;
     }
 
-    public ArrayList<String> getFailedTests() {
+    public List<String> getFailedTests() {
         return failedTests;
     }
 

--- a/fork-runner/src/main/java/com/shazam/fork/summary/HtmlSummary.java
+++ b/fork-runner/src/main/java/com/shazam/fork/summary/HtmlSummary.java
@@ -14,6 +14,7 @@ package com.shazam.fork.summary;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Plain bean class, to feed to Moustache markup files.
@@ -22,7 +23,7 @@ public class HtmlSummary {
 	public Collection<HtmlPoolSummary> pools;
 	public String title;
 	public String subtitle;
-	public ArrayList<String> ignoredTests;
+	public List<String> ignoredTests;
     public String overallStatus;
-	public ArrayList<String> failedTests;
+	public List<String> failedTests;
 }

--- a/fork-runner/src/main/java/com/shazam/fork/summary/LogSummaryPrinter.java
+++ b/fork-runner/src/main/java/com/shazam/fork/summary/LogSummaryPrinter.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import javax.annotation.Nullable;
 
@@ -45,7 +46,7 @@ public class LogSummaryPrinter implements SummaryPrinter {
         for (PoolSummary poolSummary : summary.getPoolSummaries()) {
             printMiniSummary(poolSummary);
         }
-		ArrayList<String> suppressedTests = summary.getIgnoredTests();
+		List<String> suppressedTests = summary.getIgnoredTests();
 		if (suppressedTests.isEmpty()) {
             logger.info("No suppressed tests.");
 		} else {

--- a/fork-runner/src/main/java/org/jf/dexlib/Util/TryListBuilder.java
+++ b/fork-runner/src/main/java/org/jf/dexlib/Util/TryListBuilder.java
@@ -58,7 +58,7 @@ public class TryListBuilder
 
         public int startAddress;
         public int endAddress;
-        public LinkedList<Handler> handlers;
+        public List<Handler> handlers;
 
         public int catchAllHandlerAddress;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1319 - Declarations should use Java collection interfaces such as "List" rather than specific implementation.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319

Please let me know if you have any questions.

Faisal Hameed