### PR TITLE
Code quality fix - Collection.isEmpty() should be used to test for emptiness.

### DIFF
--- a/fork-runner/src/main/java/com/shazam/fork/summary/OutcomeAggregator.java
+++ b/fork-runner/src/main/java/com/shazam/fork/summary/OutcomeAggregator.java
@@ -43,7 +43,7 @@ public class OutcomeAggregator {
             public Boolean apply(@Nullable PoolSummary input) {
                 final Collection<TestResult> testResults = input.getTestResults();
                 final Collection<Boolean> testOutcomes = transform(testResults, toTestOutcome());
-                return testOutcomes.size() > 0 && and(testOutcomes);
+                return !testOutcomes.isEmpty() && and(testOutcomes);
             }
         };
     }

--- a/fork-runner/src/main/java/org/jf/dexlib/AnnotationDirectoryItem.java
+++ b/fork-runner/src/main/java/org/jf/dexlib/AnnotationDirectoryItem.java
@@ -74,7 +74,7 @@ public class AnnotationDirectoryItem extends Item<AnnotationDirectoryItem> {
         super(dexFile);
         this.classAnnotations = classAnnotations;
 
-        if (fieldAnnotations == null || fieldAnnotations.size() == 0) {
+        if (fieldAnnotations == null || fieldAnnotations.isEmpty()) {
             this.fieldAnnotations = null;
         } else {
             this.fieldAnnotations = new FieldAnnotation[fieldAnnotations.size()];
@@ -82,7 +82,7 @@ public class AnnotationDirectoryItem extends Item<AnnotationDirectoryItem> {
             Arrays.sort(this.fieldAnnotations);
         }
 
-        if (methodAnnotations == null || methodAnnotations.size() == 0) {
+        if (methodAnnotations == null || methodAnnotations.isEmpty()) {
             this.methodAnnotations = null;
         } else {
             this.methodAnnotations = new MethodAnnotation[methodAnnotations.size()];
@@ -90,7 +90,7 @@ public class AnnotationDirectoryItem extends Item<AnnotationDirectoryItem> {
             Arrays.sort(this.methodAnnotations);
         }
 
-        if (parameterAnnotations == null || parameterAnnotations.size() == 0) {
+        if (parameterAnnotations == null || parameterAnnotations.isEmpty()) {
             this.parameterAnnotations = null;
         } else {
             this.parameterAnnotations = new ParameterAnnotation[parameterAnnotations.size()];

--- a/fork-runner/src/main/java/org/jf/dexlib/ClassDataItem.java
+++ b/fork-runner/src/main/java/org/jf/dexlib/ClassDataItem.java
@@ -89,7 +89,7 @@ public class ClassDataItem extends Item<ClassDataItem> {
         EncodedMethod[] directMethodsArray = null;
         EncodedMethod[] virtualMethodsArray = null;
 
-        if (staticFields != null && staticFields.size() > 0) {
+        if (staticFields != null && !staticFields.isEmpty()) {
             SortedSet<EncodedField> staticFieldsSet = new TreeSet<EncodedField>();
             for (EncodedField staticField: staticFields) {
                 if (staticFieldsSet.contains(staticField)) {
@@ -104,7 +104,7 @@ public class ClassDataItem extends Item<ClassDataItem> {
             staticFieldsArray = staticFieldsSet.toArray(staticFieldsArray);
         }
 
-        if (instanceFields != null && instanceFields.size() > 0) {
+        if (instanceFields != null && !instanceFields.isEmpty()) {
             SortedSet<EncodedField> instanceFieldsSet = new TreeSet<EncodedField>();
             for (EncodedField instanceField: instanceFields) {
                 if (instanceFieldsSet.contains(instanceField)) {
@@ -121,7 +121,7 @@ public class ClassDataItem extends Item<ClassDataItem> {
 
         TreeSet<EncodedMethod> directMethodSet = new TreeSet<EncodedMethod>();
 
-        if (directMethods != null && directMethods.size() > 0) {
+        if (directMethods != null && !directMethods.isEmpty()) {
             for (EncodedMethod directMethod: directMethods) {
                 if (directMethodSet.contains(directMethod)) {
                     System.err.println(String.format("Ignoring duplicate direct method definition: %s",
@@ -135,7 +135,7 @@ public class ClassDataItem extends Item<ClassDataItem> {
             directMethodsArray = directMethodSet.toArray(directMethodsArray);
         }
 
-        if (virtualMethods != null && virtualMethods.size() > 0) {
+        if (virtualMethods != null && !virtualMethods.isEmpty()) {
             TreeSet<EncodedMethod> virtualMethodSet = new TreeSet<EncodedMethod>();
             for (EncodedMethod virtualMethod: virtualMethods) {
                 if (directMethodSet.contains(virtualMethod)) {

--- a/fork-runner/src/main/java/org/jf/dexlib/ClassDefItem.java
+++ b/fork-runner/src/main/java/org/jf/dexlib/ClassDefItem.java
@@ -113,7 +113,7 @@ public class ClassDefItem extends Item<ClassDefItem> {
                          @Nullable ClassDataItem classData,
                          @Nullable List<StaticFieldInitializer> staticFieldInitializers) {
         EncodedArrayItem encodedArrayItem = null;
-        if(!dexFile.getInplace() && staticFieldInitializers != null && staticFieldInitializers.size() > 0) {
+        if(!dexFile.getInplace() && staticFieldInitializers != null && !staticFieldInitializers.isEmpty()) {
             assert classData != null;
             assert staticFieldInitializers.size() == classData.getStaticFieldCount();
             encodedArrayItem = makeStaticFieldInitializersItem(dexFile, staticFieldInitializers);
@@ -329,7 +329,7 @@ public class ClassDefItem extends Item<ClassDefItem> {
      */
     private static EncodedArrayItem makeStaticFieldInitializersItem(DexFile dexFile,
             @Nonnull List<StaticFieldInitializer> staticFieldInitializers) {
-        if (staticFieldInitializers.size() == 0) {
+        if (staticFieldInitializers.isEmpty()) {
             return null;
         }
 

--- a/fork-runner/src/main/java/org/jf/dexlib/Code/Analysis/AnalyzedInstruction.java
+++ b/fork-runner/src/main/java/org/jf/dexlib/Code/Analysis/AnalyzedInstruction.java
@@ -158,7 +158,7 @@ public class AnalyzedInstruction implements Comparable<AnalyzedInstruction> {
     public boolean isBeginningInstruction() {
         //if this instruction has no predecessors, it is either the fake "StartOfMethod" instruction or it is an
         //unreachable instruction.
-        if (predecessors.size() == 0) {
+        if (predecessors.isEmpty()) {
             return false;
         }
 

--- a/fork-runner/src/main/java/org/jf/dexlib/Code/Analysis/ClassPath.java
+++ b/fork-runner/src/main/java/org/jf/dexlib/Code/Analysis/ClassPath.java
@@ -1282,7 +1282,7 @@ public class ClassPath {
             TypeListItem typeList = classDefItem.getInterfaces();
             if (typeList != null) {
                 List<TypeIdItem> types = typeList.getTypes();
-                if (types != null && types.size() > 0) {
+                if (types != null && !types.isEmpty()) {
                     String[] interfaces = new String[types.size()];
                     for (int i=0; i<interfaces.length; i++) {
                         interfaces[i] = types.get(i).getTypeDescriptor();
@@ -1295,7 +1295,7 @@ public class ClassPath {
 
         private String[] loadDirectMethods(ClassDataItem classDataItem, boolean[][] _staticMethods) {
             List<EncodedMethod> encodedMethods = classDataItem.getDirectMethods();
-            if (encodedMethods.size() > 0) {
+            if (!encodedMethods.isEmpty()) {
                 boolean[] staticMethods = new boolean[encodedMethods.size()];
                 String[] directMethods = new String[encodedMethods.size()];
 
@@ -1315,7 +1315,7 @@ public class ClassPath {
 
         private VirtualMethod[] loadVirtualMethods(ClassDataItem classDataItem) {
             List<EncodedMethod> encodedMethods = classDataItem.getVirtualMethods();
-            if (encodedMethods.size() > 0) {
+            if (!encodedMethods.isEmpty()) {
                 VirtualMethod[] virtualMethods = new VirtualMethod[encodedMethods.size()];
                 for (int i=0; i<encodedMethods.size(); i++) {
                     virtualMethods[i] = new VirtualMethod();
@@ -1338,7 +1338,7 @@ public class ClassPath {
 
         private String[][] loadInstanceFields(ClassDataItem classDataItem) {
             List<EncodedField> encodedFields = classDataItem.getInstanceFields();
-            if (encodedFields.size() > 0) {
+            if (!encodedFields.isEmpty()) {
                 String[][] instanceFields = new String[encodedFields.size()][2];
                 for (int i=0; i<encodedFields.size(); i++) {
                     EncodedField encodedField = encodedFields.get(i);

--- a/fork-runner/src/main/java/org/jf/dexlib/CodeItem.java
+++ b/fork-runner/src/main/java/org/jf/dexlib/CodeItem.java
@@ -114,17 +114,17 @@ public class CodeItem extends Item<CodeItem> {
         EncodedCatchHandler[] encodedCatchHandlersArray = null;
         Instruction[] instructionsArray = null;
 
-        if (tries != null && tries.size() > 0) {
+        if (tries != null && !tries.isEmpty()) {
             triesArray = new TryItem[tries.size()];
             tries.toArray(triesArray);
         }
 
-        if (encodedCatchHandlers != null && encodedCatchHandlers.size() > 0) {
+        if (encodedCatchHandlers != null && !encodedCatchHandlers.isEmpty()) {
             encodedCatchHandlersArray = new EncodedCatchHandler[encodedCatchHandlers.size()];
             encodedCatchHandlers.toArray(encodedCatchHandlersArray);
         }
 
-        if (instructions != null && instructions.size() > 0) {
+        if (instructions != null && !instructions.isEmpty()) {
             instructionsArray = new Instruction[instructions.size()];
             instructions.toArray(instructionsArray);
         }

--- a/fork-runner/src/main/java/org/jf/dexlib/Section.java
+++ b/fork-runner/src/main/java/org/jf/dexlib/Section.java
@@ -84,7 +84,7 @@ public abstract class Section<T extends Item> {
      * @return the offset of the byte immediate after the last item in this section
      */
     protected int placeAt(int offset) {
-        if (items.size() > 0) {
+        if (!items.isEmpty()) {
             offset = AlignmentUtils.alignOffset(offset, ItemType.ItemAlignment);
             assert !DexFile.getInplace() || offset == this.offset;
             this.offset = offset;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1155 - Collection.isEmpty() should be used to test for emptiness. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155

Please let me know if you have any questions.

Faisal Hameed