### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/fork-common/src/main/java/com/shazam/fork/CommonDefaults.java
+++ b/fork-common/src/main/java/com/shazam/fork/CommonDefaults.java
@@ -11,6 +11,9 @@
 package com.shazam.fork;
 
 public class CommonDefaults {
+
+    private CommonDefaults() {}
+
     public static final String FORK = "fork-";
     public static final String JSON = "json";
     public static final String FORK_SUMMARY_FILENAME_FORMAT = FORK + "%s." + JSON;

--- a/fork-common/src/main/java/com/shazam/fork/io/Files.java
+++ b/fork-common/src/main/java/com/shazam/fork/io/Files.java
@@ -17,6 +17,8 @@ import static org.apache.commons.io.IOUtils.closeQuietly;
 
 public class Files {
 
+    private Files() {}
+
     public static void copyResource(String fromDir, String assetName, File toDir) {
         InputStream resourceAsStream = Files.class.getResourceAsStream(fromDir + assetName);
         File assetFile = new File(toDir, assetName);

--- a/fork-common/src/main/java/com/shazam/fork/utils/ReadableNames.java
+++ b/fork-common/src/main/java/com/shazam/fork/utils/ReadableNames.java
@@ -14,6 +14,8 @@ import static org.apache.commons.lang3.text.WordUtils.capitalizeFully;
 
 public class ReadableNames {
 
+    private ReadableNames() {}
+
     public static String readablePoolName(String poolName) {
         return capitalize(poolName);
     }

--- a/fork-common/src/main/java/com/shazam/fork/utils/Utils.java
+++ b/fork-common/src/main/java/com/shazam/fork/utils/Utils.java
@@ -16,6 +16,8 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 public class Utils {
 
+    private Utils() {}
+    
     public static long millisSinceNanoTime(long startNanos) {
         return millisBetweenNanoTimes(startNanos, nanoTime());
     }

--- a/fork-reporter/src/main/java/com/shazam/fork/reporter/ForkReporterCli.java
+++ b/fork-reporter/src/main/java/com/shazam/fork/reporter/ForkReporterCli.java
@@ -23,6 +23,8 @@ import static com.shazam.fork.reporter.ForkReporter.Builder.forkReporter;
 public class ForkReporterCli {
     private static final Logger logger = LoggerFactory.getLogger(ForkReporterCli.class);
 
+    private ForkReporterCli() {}
+
     public static void main(String... args) {
         CommandLineArgs parsedArgs = new CommandLineArgs();
         JCommander jc = new JCommander(parsedArgs);

--- a/fork-reporter/src/main/java/com/shazam/fork/reporter/injector/BuildLinkCreatorInjector.java
+++ b/fork-reporter/src/main/java/com/shazam/fork/reporter/injector/BuildLinkCreatorInjector.java
@@ -16,6 +16,9 @@ import com.shazam.fork.reporter.TokenBuildLinkCreator;
 import static com.shazam.fork.reporter.injector.ConfigurationInjector.configuration;
 
 public class BuildLinkCreatorInjector {
+
+    private BuildLinkCreatorInjector() {}
+
     public static BuildLinkCreator buildLinkCreator() {
         if (configuration().shouldCreateLinks()) {
             return new TokenBuildLinkCreator(configuration().getBaseUrl());

--- a/fork-reporter/src/main/java/com/shazam/fork/reporter/injector/ConfigurationInjector.java
+++ b/fork-reporter/src/main/java/com/shazam/fork/reporter/injector/ConfigurationInjector.java
@@ -16,6 +16,8 @@ public class ConfigurationInjector {
 
     private static Configuration configuration;
 
+    private ConfigurationInjector() {}
+
     public static void setConfiguration(Configuration configuration) {
         ConfigurationInjector.configuration = configuration;
     }

--- a/fork-reporter/src/main/java/com/shazam/fork/reporter/injector/ExecutionReaderInjector.java
+++ b/fork-reporter/src/main/java/com/shazam/fork/reporter/injector/ExecutionReaderInjector.java
@@ -17,6 +17,8 @@ import static com.shazam.fork.reporter.injector.GsonInjector.gson;
 
 public class ExecutionReaderInjector {
 
+    private ExecutionReaderInjector() {}
+
     public static ExecutionReader executionReader() {
         return new ExecutionReader(fileManager(), gson());
     }

--- a/fork-reporter/src/main/java/com/shazam/fork/reporter/injector/FileManagerInjector.java
+++ b/fork-reporter/src/main/java/com/shazam/fork/reporter/injector/FileManagerInjector.java
@@ -16,6 +16,8 @@ import static com.shazam.fork.reporter.injector.ConfigurationInjector.configurat
 
 public class FileManagerInjector {
 
+    private FileManagerInjector() {}
+
     public static FileManager fileManager() {
         return new FileManager(configuration().getInput());
     }

--- a/fork-reporter/src/main/java/com/shazam/fork/reporter/injector/FlakinessReportPrinterInjector.java
+++ b/fork-reporter/src/main/java/com/shazam/fork/reporter/injector/FlakinessReportPrinterInjector.java
@@ -21,6 +21,9 @@ import static com.shazam.fork.reporter.injector.HtmlGeneratorInjector.htmlGenera
 import static com.shazam.fork.reporter.injector.TestFlakinessToHtmlReportConverterInjector.converter;
 
 public class FlakinessReportPrinterInjector {
+
+    private FlakinessReportPrinterInjector() {}
+
     public static FlakinessReportPrinter flakinessReportPrinter() {
         File output = configuration().getOutput();
         return new HtmlFlakinessReportPrinter(output, htmlGenerator(), converter());

--- a/fork-reporter/src/main/java/com/shazam/fork/reporter/injector/FlakinessSorterInjector.java
+++ b/fork-reporter/src/main/java/com/shazam/fork/reporter/injector/FlakinessSorterInjector.java
@@ -17,6 +17,9 @@ import static com.shazam.fork.reporter.injector.ConfigurationInjector.configurat
 import static com.shazam.fork.reporter.injector.TestLinkCreatorInjector.testLinkCreator;
 
 public class FlakinessSorterInjector {
+
+    private FlakinessSorterInjector() {}
+
     public static FlakinessSorter flakinessSorter() {
         return new FlakinessSorter(configuration().getTitle(), buildLinkCreator(), testLinkCreator());
     }

--- a/fork-reporter/src/main/java/com/shazam/fork/reporter/injector/GsonInjector.java
+++ b/fork-reporter/src/main/java/com/shazam/fork/reporter/injector/GsonInjector.java
@@ -13,6 +13,9 @@ package com.shazam.fork.reporter.injector;
 import com.google.gson.Gson;
 
 public class GsonInjector {
+
+    private GsonInjector() {}
+
     private static final Gson GSON = new Gson();
 
     public static Gson gson() {

--- a/fork-reporter/src/main/java/com/shazam/fork/reporter/injector/HtmlGeneratorInjector.java
+++ b/fork-reporter/src/main/java/com/shazam/fork/reporter/injector/HtmlGeneratorInjector.java
@@ -16,6 +16,8 @@ import com.shazam.fork.io.HtmlGenerator;
 public class HtmlGeneratorInjector {
     private static final DefaultMustacheFactory MUSTACHE_FACTORY = new DefaultMustacheFactory();
 
+    private HtmlGeneratorInjector() {}
+
     public static HtmlGenerator htmlGenerator() {
         return new HtmlGenerator(MUSTACHE_FACTORY);
     }

--- a/fork-runner/src/main/java/com/shazam/fork/Defaults.java
+++ b/fork-runner/src/main/java/com/shazam/fork/Defaults.java
@@ -11,6 +11,9 @@
 package com.shazam.fork;
 
 class Defaults {
+
+    private Defaults() {}
+
     public static final int TEST_OUTPUT_TIMEOUT_MILLIS = 60 * 1000;
     public static final String TEST_CLASS_REGEX = "^((?!Abstract).)*Test$";
     public static final String TEST_OUTPUT = "fork-output";

--- a/fork-runner/src/main/java/com/shazam/fork/ForkCli.java
+++ b/fork-runner/src/main/java/com/shazam/fork/ForkCli.java
@@ -27,6 +27,8 @@ public class ForkCli {
 
     private static final Logger logger = LoggerFactory.getLogger(ForkCli.class);
 
+    private ForkCli() {}
+
     public static class CommandLineArgs {
 
         @Parameter(names = { "--sdk" }, description = "Path to Android SDK", converter = FileConverter.class)

--- a/fork-runner/src/main/java/com/shazam/fork/injector/ConfigurationInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/ConfigurationInjector.java
@@ -19,6 +19,8 @@ import java.io.File;
 public class ConfigurationInjector {
     private static Configuration configuration;
 
+    private ConfigurationInjector() {}
+
     public static void setConfiguration(Configuration configuration) {
         ConfigurationInjector.configuration = configuration;
     }

--- a/fork-runner/src/main/java/com/shazam/fork/injector/ForkRunnerInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/ForkRunnerInjector.java
@@ -29,6 +29,8 @@ public class ForkRunnerInjector {
 
     private static final Logger logger = LoggerFactory.getLogger(ForkRunnerInjector.class);
 
+    private ForkRunnerInjector() {}
+
     public static ForkRunner forkRunner() {
         long startNanos = nanoTime();
 

--- a/fork-runner/src/main/java/com/shazam/fork/injector/GsonInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/GsonInjector.java
@@ -17,6 +17,8 @@ import com.google.gson.Gson;
 public class GsonInjector {
     private static final Gson GSON = new Gson();
 
+    private GsonInjector() {}
+
     public static Gson gson() {
         return GSON;
     }

--- a/fork-runner/src/main/java/com/shazam/fork/injector/RuntimeConfigurationInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/RuntimeConfigurationInjector.java
@@ -21,6 +21,8 @@ import static com.shazam.fork.injector.pooling.ComputedPoolsConfigurationFactory
 
 public class RuntimeConfigurationInjector {
 
+    private RuntimeConfigurationInjector() {}
+
     private static final RuntimeConfiguration RUNTIME_CONFIGURATION = aRuntimeConfiguration()
             .withFilterPattern(extractFilterPattern())
             .whichUsesTabletFlag(extractTabletFlag())

--- a/fork-runner/src/main/java/com/shazam/fork/injector/accumulator/PoolTestCaseFailureAccumulatorInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/accumulator/PoolTestCaseFailureAccumulatorInjector.java
@@ -3,6 +3,7 @@ package com.shazam.fork.injector.accumulator;
 import com.shazam.fork.model.PoolTestCaseFailureAccumulator;
 
 public class PoolTestCaseFailureAccumulatorInjector {
+    private PoolTestCaseFailureAccumulatorInjector() {};
     public static PoolTestCaseFailureAccumulator poolTestCaseFailureAccumulator() {
         return new PoolTestCaseFailureAccumulator();
     }

--- a/fork-runner/src/main/java/com/shazam/fork/injector/listeners/TestRunListenersFactoryInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/listeners/TestRunListenersFactoryInjector.java
@@ -18,6 +18,8 @@ import static com.shazam.fork.injector.GsonInjector.gson;
 
 public class TestRunListenersFactoryInjector {
 
+    private TestRunListenersFactoryInjector() {}
+
     public static TestRunListenersFactory testRunListenersFactory() {
         return new TestRunListenersFactory(configuration(), fileManager(), gson());
     }

--- a/fork-runner/src/main/java/com/shazam/fork/injector/pooling/CommandOutputLoggerInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/pooling/CommandOutputLoggerInjector.java
@@ -19,6 +19,8 @@ import static com.shazam.fork.injector.ConfigurationInjector.configuredOutput;
 
 public class CommandOutputLoggerInjector {
 
+    private CommandOutputLoggerInjector() {}
+
     public static CommandOutputLogger commandOutputLogger(String command) {
         return new GeometryCommandOutputLogger(configuredOutput(), command);
     }

--- a/fork-runner/src/main/java/com/shazam/fork/injector/pooling/ComputedPoolsConfigurationFactoryInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/pooling/ComputedPoolsConfigurationFactoryInjector.java
@@ -13,6 +13,7 @@ package com.shazam.fork.injector.pooling;
 import com.shazam.fork.pooling.ComputedPoolsConfigurationFactory;
 
 public class ComputedPoolsConfigurationFactoryInjector {
+    private ComputedPoolsConfigurationFactoryInjector() {}
     public static ComputedPoolsConfigurationFactory computedPoolsConfigurationFactory() {
         return new ComputedPoolsConfigurationFactory();
     }

--- a/fork-runner/src/main/java/com/shazam/fork/injector/pooling/DeviceGeometryRetrieverInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/pooling/DeviceGeometryRetrieverInjector.java
@@ -23,6 +23,8 @@ import static com.shazam.fork.injector.pooling.CommandOutputLoggerInjector.comma
 
 class DeviceGeometryRetrieverInjector {
 
+    private DeviceGeometryRetrieverInjector() {}
+
     /**
      * Nexus S, Samsumg GT-P5110.
      * Also (h\\d+)dp and (w\\d+)dp if you want them...

--- a/fork-runner/src/main/java/com/shazam/fork/injector/pooling/DeviceLoaderInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/pooling/DeviceLoaderInjector.java
@@ -20,6 +20,8 @@ import static com.shazam.fork.injector.RuntimeConfigurationInjector.runtimeConfi
 
 public class DeviceLoaderInjector {
 
+    private DeviceLoaderInjector() {}
+
     public static DeviceLoader deviceLoader() {
         return new DeviceLoader(androidDebugBridge(), deviceGeometryReader(), runtimeConfiguration());
     }

--- a/fork-runner/src/main/java/com/shazam/fork/injector/pooling/DevicePoolLoaderInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/pooling/DevicePoolLoaderInjector.java
@@ -22,6 +22,8 @@ import static com.shazam.fork.injector.RuntimeConfigurationInjector.runtimeConfi
 
 public class DevicePoolLoaderInjector {
 
+    private DevicePoolLoaderInjector() {}
+
     public static DevicePoolLoader devicePoolLoader() {
         return new CompositeDevicePoolLoader(devicePoolLoaders(runtimeConfiguration()));
     }

--- a/fork-runner/src/main/java/com/shazam/fork/injector/pooling/PoolLoaderInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/pooling/PoolLoaderInjector.java
@@ -17,6 +17,8 @@ import static com.shazam.fork.injector.pooling.DevicePoolLoaderInjector.devicePo
 
 public class PoolLoaderInjector {
 
+    private PoolLoaderInjector() {}
+
     public static PoolLoader poolLoader() {
         return new PoolLoader(deviceLoader(), devicePoolLoader());
     }

--- a/fork-runner/src/main/java/com/shazam/fork/injector/pooling/PoolingStrategyInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/pooling/PoolingStrategyInjector.java
@@ -22,6 +22,8 @@ import static java.util.Arrays.asList;
 
 public class PoolingStrategyInjector {
 
+    private PoolingStrategyInjector() {}
+
     public static Collection<ComputedPoolingStrategy> poolingStrategies() {
         return asList(new ComputedPoolingBySmallestWidth(), new ComputedPoolingByApi());
 

--- a/fork-runner/src/main/java/com/shazam/fork/injector/runner/DeviceTestRunnerFactoryInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/runner/DeviceTestRunnerFactoryInjector.java
@@ -16,6 +16,7 @@ import static com.shazam.fork.injector.system.InstallerInjector.installer;
 import static com.shazam.fork.injector.runner.TestRunFactoryInjector.testRunFactory;
 
 public class DeviceTestRunnerFactoryInjector {
+    private DeviceTestRunnerFactoryInjector() {}
 
     public static DeviceTestRunnerFactory deviceTestRunnerFactory() {
         return new DeviceTestRunnerFactory(installer(), testRunFactory());

--- a/fork-runner/src/main/java/com/shazam/fork/injector/runner/PoolProgressTrackersInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/runner/PoolProgressTrackersInjector.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import static com.beust.jcommander.internal.Maps.newHashMap;
 
 public class PoolProgressTrackersInjector {
+    private PoolProgressTrackersInjector() {}
     public static Map<Pool, PoolProgressTracker> poolProgressTrackers() {
         return newHashMap();
     }

--- a/fork-runner/src/main/java/com/shazam/fork/injector/runner/PoolTestRunnerFactoryInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/runner/PoolTestRunnerFactoryInjector.java
@@ -15,6 +15,7 @@ import com.shazam.fork.runner.PoolTestRunnerFactory;
 import static com.shazam.fork.injector.runner.DeviceTestRunnerFactoryInjector.deviceTestRunnerFactory;
 
 public class PoolTestRunnerFactoryInjector {
+    private PoolTestRunnerFactoryInjector(){};
 
     public static PoolTestRunnerFactory poolTestRunnerFactory() {
         return new PoolTestRunnerFactory(deviceTestRunnerFactory());

--- a/fork-runner/src/main/java/com/shazam/fork/injector/runner/ProgressReporterInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/runner/ProgressReporterInjector.java
@@ -19,6 +19,8 @@ import static com.shazam.fork.injector.accumulator.PoolTestCaseFailureAccumulato
 
 public class ProgressReporterInjector {
 
+    private ProgressReporterInjector() {}
+
     public static ProgressReporter progressReporter() {
         return new OverallProgressReporter(configuration(),
                 poolProgressTrackers(),

--- a/fork-runner/src/main/java/com/shazam/fork/injector/suite/TestClassFactoryInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/suite/TestClassFactoryInjector.java
@@ -14,6 +14,8 @@ import com.shazam.fork.suite.TestClassFactory;
 
 class TestClassFactoryInjector {
 
+    private TestClassFactoryInjector() {}
+
     static TestClassFactory testClassFactory() {
         return new TestClassFactory();
     }

--- a/fork-runner/src/main/java/com/shazam/fork/injector/suite/TestClassFilterInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/suite/TestClassFilterInjector.java
@@ -17,6 +17,7 @@ import com.shazam.fork.suite.TestClassFilter;
 import static com.shazam.fork.injector.RuntimeConfigurationInjector.runtimeConfiguration;
 
 class TestClassFilterInjector {
+    private TestClassFilterInjector() {}
     public static TestClassFilter testClassFilter() {
         return new TestClassFilter(runtimeConfiguration().getFilterPattern());
     }

--- a/fork-runner/src/main/java/com/shazam/fork/injector/suite/TestClassLoaderInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/suite/TestClassLoaderInjector.java
@@ -16,7 +16,7 @@ import static com.shazam.fork.injector.suite.TestClassFilterInjector.testClassFi
 import static com.shazam.fork.injector.suite.TestClassScannerInjector.testClassScanner;
 
 public class TestClassLoaderInjector {
-
+    private TestClassLoaderInjector() {}
     public static TestClassLoader testClassLoader() {
         return new TestClassLoader(testClassScanner(), testClassFilter());
     }

--- a/fork-runner/src/main/java/com/shazam/fork/injector/suite/TestClassMatcherInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/suite/TestClassMatcherInjector.java
@@ -21,6 +21,8 @@ import static com.shazam.fork.injector.ConfigurationInjector.configuration;
 class TestClassMatcherInjector {
     private static final Logger log = LoggerFactory.getLogger(TestClassMatcherInjector.class);
 
+    private TestClassMatcherInjector() {}
+
     static TestClassMatcher testClassMatcher() {
         Configuration configuration = configuration();
         log.info("Fork will try to find tests in {} from your instrumentation APK.", configuration.getTestPackage());

--- a/fork-runner/src/main/java/com/shazam/fork/injector/suite/TestClassScannerInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/suite/TestClassScannerInjector.java
@@ -21,6 +21,8 @@ import static com.shazam.fork.injector.suite.TestClassMatcherInjector.testClassM
 
 class TestClassScannerInjector {
 
+    private TestClassScannerInjector() {}
+
     public static TestClassScanner testClassScanner() {
         return new TestClassScanner(
                 configuration().getInstrumentationApk(),

--- a/fork-runner/src/main/java/com/shazam/fork/injector/summary/HtmlGeneratorInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/summary/HtmlGeneratorInjector.java
@@ -16,6 +16,8 @@ import com.shazam.fork.io.HtmlGenerator;
 public class HtmlGeneratorInjector {
     private static final DefaultMustacheFactory MUSTACHE_FACTORY = new DefaultMustacheFactory();
 
+    private HtmlGeneratorInjector() {}
+
     public static HtmlGenerator htmlGenerator() {
         return new HtmlGenerator(MUSTACHE_FACTORY);
     }

--- a/fork-runner/src/main/java/com/shazam/fork/injector/summary/LogCatRetrieverInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/summary/LogCatRetrieverInjector.java
@@ -19,6 +19,7 @@ import static com.shazam.fork.injector.system.FileManagerInjector.fileManager;
 import static com.shazam.fork.injector.GsonInjector.gson;
 
 public class LogCatRetrieverInjector {
+    private LogCatRetrieverInjector() {}
     public static LogCatRetriever logCatRetriever() {
         return new JsonLogCatRetriever(gson(), fileManager());
     }

--- a/fork-runner/src/main/java/com/shazam/fork/injector/summary/SummarizerInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/summary/SummarizerInjector.java
@@ -18,6 +18,8 @@ import static com.shazam.fork.injector.summary.SummaryPrinterInjector.summaryPri
 
 public class SummarizerInjector {
 
+    private SummarizerInjector(){}
+
     public static Summarizer summarizer() {
         return new Summarizer(summaryCompiler(), summaryPrinter(), outcomeAggregator());
     }

--- a/fork-runner/src/main/java/com/shazam/fork/injector/summary/SummaryCompilerInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/summary/SummaryCompilerInjector.java
@@ -16,6 +16,7 @@ import static com.shazam.fork.injector.RuntimeConfigurationInjector.runtimeConfi
 import static com.shazam.fork.injector.system.FileManagerInjector.fileManager;
 
 class SummaryCompilerInjector {
+    private SummaryCompilerInjector() {}
     static SummaryCompiler summaryCompiler() {
         return new SummaryCompiler(runtimeConfiguration(), fileManager());
     }

--- a/fork-runner/src/main/java/com/shazam/fork/injector/summary/SummaryGeneratorHookInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/summary/SummaryGeneratorHookInjector.java
@@ -15,6 +15,7 @@ import com.shazam.fork.summary.SummaryGeneratorHook;
 import static com.shazam.fork.injector.summary.SummarizerInjector.summarizer;
 
 public class SummaryGeneratorHookInjector {
+    private SummaryGeneratorHookInjector() {}
     public static SummaryGeneratorHook summaryGeneratorHook() {
         return new SummaryGeneratorHook(summarizer());
     }

--- a/fork-runner/src/main/java/com/shazam/fork/injector/summary/SummaryPrinterInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/summary/SummaryPrinterInjector.java
@@ -22,6 +22,8 @@ import static com.shazam.fork.injector.system.FileManagerInjector.fileManager;
 
 public class SummaryPrinterInjector {
 
+    private SummaryPrinterInjector() {}
+
     public static SummaryPrinter summaryPrinter() {
         return new CompositeSummaryPrinter(consoleSummaryPrinter(), htmlSummaryPrinter(), jsonSummarySerializer());
     }

--- a/fork-runner/src/main/java/com/shazam/fork/injector/system/AndroidDebugBridgeInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/system/AndroidDebugBridgeInjector.java
@@ -20,6 +20,8 @@ import static com.shazam.fork.injector.ConfigurationInjector.configuration;
 public class AndroidDebugBridgeInjector {
     private static final AndroidDebugBridge ADB = initAdb(configuration().getAndroidSdk());
 
+    private AndroidDebugBridgeInjector() {}
+
     public static AndroidDebugBridge androidDebugBridge() {
         return ADB;
     }

--- a/fork-runner/src/main/java/com/shazam/fork/injector/system/FileManagerInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/system/FileManagerInjector.java
@@ -6,6 +6,7 @@ import static com.shazam.fork.injector.ConfigurationInjector.configuration;
 
 public class FileManagerInjector {
 
+    private FileManagerInjector() {}
     public static FileManager fileManager() {
         return new FileManager(configuration().getOutput());
     }

--- a/fork-runner/src/main/java/com/shazam/fork/injector/system/InstallerInjector.java
+++ b/fork-runner/src/main/java/com/shazam/fork/injector/system/InstallerInjector.java
@@ -20,6 +20,8 @@ import static com.shazam.fork.injector.ConfigurationInjector.configuration;
 
 public class InstallerInjector {
 
+    private InstallerInjector() {}
+
     public static Installer installer() {
         Configuration configuration = configuration();
         InstrumentationInfo info = configuration.getInstrumentationInfo();

--- a/fork-runner/src/main/java/com/shazam/fork/system/RuntimeConfigurationExtractor.java
+++ b/fork-runner/src/main/java/com/shazam/fork/system/RuntimeConfigurationExtractor.java
@@ -27,6 +27,8 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 public class RuntimeConfigurationExtractor {
     private static final Logger logger = LoggerFactory.getLogger(RuntimeConfigurationExtractor.class);
 
+    private RuntimeConfigurationExtractor() {}
+
     @Nullable
     public static String extractFilterPattern() {
         String filterPattern = valueFrom(PARAMETER_TEST_CLASSES);

--- a/fork-runner/src/main/java/com/shazam/fork/system/axmlparser/Cast.java
+++ b/fork-runner/src/main/java/com/shazam/fork/system/axmlparser/Cast.java
@@ -21,6 +21,7 @@ package com.shazam.fork.system.axmlparser;
  */
 @SuppressWarnings("ALL")
 public class Cast {
+    private Cast() {}
 
     public static final CharSequence toCharSequence(String string) {
         if (string==null) {

--- a/fork-runner/src/main/java/com/shazam/fork/system/axmlparser/InstumentationInfoFactory.java
+++ b/fork-runner/src/main/java/com/shazam/fork/system/axmlparser/InstumentationInfoFactory.java
@@ -27,6 +27,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class InstumentationInfoFactory {
 
+    private InstumentationInfoFactory() {}
+
 	/**
      * @param apkTestFile the instrumentation APK
      * @return the instrumentation info instance

--- a/fork-runner/src/main/java/com/shazam/fork/system/axmlparser/ReadUtil.java
+++ b/fork-runner/src/main/java/com/shazam/fork/system/axmlparser/ReadUtil.java
@@ -26,6 +26,8 @@ import java.io.InputStream;
 @SuppressWarnings("ALL")
 public class ReadUtil {
 
+    private ReadUtil() {}
+
     public static final void readCheckType(InputStream stream,int expectedType) throws IOException {
         int type=readInt(stream);
         if (type!=expectedType) {

--- a/fork-runner/src/main/java/com/shazam/fork/system/io/RemoteFileManager.java
+++ b/fork-runner/src/main/java/com/shazam/fork/system/io/RemoteFileManager.java
@@ -30,6 +30,8 @@ public class RemoteFileManager {
     private static final NullOutputReceiver NO_OP_RECEIVER = new NullOutputReceiver();
     private static final String COVERAGE_DIRECTORY = FORK_DIRECTORY + "/coverage";
 
+    private RemoteFileManager() {}
+
     public static void removeRemotePath(IDevice device, String remotePath) {
         executeCommand(device, "rm " + remotePath, "Could not delete remote file(s): " + remotePath);
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed