### PR TITLE
Fixing OOBE if the type descriptor does not contain a '/', ie class w…

### DIFF
--- a/fork-common/src/main/java/com/shazam/fork/suite/PackageAndClassNameMatcher.java
+++ b/fork-common/src/main/java/com/shazam/fork/suite/PackageAndClassNameMatcher.java
@@ -23,9 +23,14 @@ public class PackageAndClassNameMatcher implements TestClassMatcher {
 
     @Override
     public boolean matchesPatterns(String typeDescriptor) {
-        String packageName = getPackageName(typeDescriptor);
-        String className = getClassName(typeDescriptor);
-        return packagePattern.matcher(packageName).matches() && classPattern.matcher(className).matches();
+        try {
+            String packageName = getPackageName(typeDescriptor);
+            String className = getClassName(typeDescriptor);
+            return packagePattern.matcher(packageName).matches() && classPattern.matcher(className).matches();
+        } catch (StringIndexOutOfBoundsException ignored) {
+            return false;
+        }
+
     }
 
     private String getClassName(String typeDescriptor) {


### PR DESCRIPTION
Hi guys!
 
Fork was crashing while loading the test suite if a class did not have a package (I know something not very common), so i have done a quick fix, and therefore i am submitting a pull request just in case you are interested on it.

If you want to reproduce it, just add jmock as an androidTest dependency ie:
`androidTestCompile 'org.jmock:jmock-junit4:2.8.2'`

Jmock is adding a dependency called "jmock-testjar" that has a couple of classes without a package --> https://github.com/jmock-developers/jmock-library/tree/jmock2/testjar/src/main/java
