### PR TITLE
Fixing fork to run on library modules.

### DIFF
--- a/fork-gradle-plugin/src/main/groovy/com/shazam/fork/gradle/ForkPlugin.groovy
+++ b/fork-gradle-plugin/src/main/groovy/com/shazam/fork/gradle/ForkPlugin.groovy
@@ -66,6 +66,10 @@ class ForkPlugin implements Plugin<Project> {
             def firstTestedVariantOutput = variant.testedVariant.outputs.get(0)
             applicationApk = firstTestedVariantOutput.outputFile
             instrumentationApk = variant.outputs.get(0).outputFile
+            //If we are testing a library, the app apk must be the same than the instrumentation apk
+            if (applicationApk.path.endsWith("aar")) {
+                applicationApk = instrumentationApk
+            }
 
             String baseOutputDir = config.baseOutputDir
             File outputBase


### PR DESCRIPTION
Snapshot version of fork does not work on library modules. 
Setting the appApk to be the same than the instrumentation Apk fixes the problem.

Probably not the cleanest way to fix it, but the one with less impact on the whole library.