### PR TITLE
Fixing inconsistency on test coverage files

### DIFF
--- a/fork-runner/src/main/java/com/shazam/fork/runner/TestRun.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/TestRun.java
@@ -55,7 +55,7 @@ class TestRun {
 
         if (testRunParameters.isCoverageEnabled()) {
             runner.setCoverage(true);
-            runner.addInstrumentationArg("coverageFile", RemoteFileManager.getCoverageFileName(testClassName));
+            runner.addInstrumentationArg("coverageFile", RemoteFileManager.getCoverageFileName(new TestIdentifier(testClassName, testMethodName)));
         }
 
 		try {

--- a/fork-runner/src/main/java/com/shazam/fork/runner/listeners/CoverageListener.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/listeners/CoverageListener.java
@@ -63,8 +63,9 @@ public class CoverageListener implements ITestRunListener {
 
     @Override
     public void testRunEnded(long elapsedTime, Map<String, String> runMetrics) {
-        final String remoteFile = RemoteFileManager.getCoverageFileName(testCase.getTestClass());
-        final File file = fileManager.createFile(COVERAGE, pool, device, testCase);
+        TestIdentifier testIdentifier = new TestIdentifier(testCase.getTestClass(), testCase.getTestMethod());
+        final String remoteFile = RemoteFileManager.getCoverageFileName(testIdentifier);
+        final File file = fileManager.createFile(COVERAGE, pool, device, testIdentifier);
         try {
             device.getDeviceInterface().pullFile(remoteFile, file.getAbsolutePath());
         } catch (Exception e) {

--- a/fork-runner/src/main/java/com/shazam/fork/system/io/RemoteFileManager.java
+++ b/fork-runner/src/main/java/com/shazam/fork/system/io/RemoteFileManager.java
@@ -41,8 +41,8 @@ public class RemoteFileManager {
                        "Could not create remote directory: " + COVERAGE_DIRECTORY);
     }
 
-    public static String getCoverageFileName(String testClassName) {
-        return COVERAGE_DIRECTORY + "/" + testClassName + ".ec";
+    public static String getCoverageFileName(TestIdentifier testIdentifier) {
+        return COVERAGE_DIRECTORY + "/" +testIdentifier.toString() + ".ec";
     }
 
     public static void createRemoteDirectory(IDevice device) {


### PR DESCRIPTION
Fork was generating a single file per test class but creating one file for every single test case in the report.

This was causing some issues while trying to merge the coverage files
