### PR TITLE
CHIM-266 Enabling a way to pass the notAnnotation down to the test ru…

### DIFF
--- a/fork-gradle-plugin/src/main/groovy/com/shazam/fork/gradle/ForkPlugin.groovy
+++ b/fork-gradle-plugin/src/main/groovy/com/shazam/fork/gradle/ForkPlugin.groovy
@@ -93,7 +93,7 @@ class ForkPlugin implements Plugin<Project> {
             poolingStrategy = config.poolingStrategy
             autoGrantPermissions = config.autoGrantPermissions
             ignoreFailures = config.ignoreFailures
-
+            excludedAnnotation = config.excludedAnnotation
             dependsOn firstTestedVariantOutput.assemble, variant.assemble
         }
         forkTask.outputs.upToDateWhen { false }

--- a/fork-gradle-plugin/src/main/groovy/com/shazam/fork/gradle/ForkRunTask.groovy
+++ b/fork-gradle-plugin/src/main/groovy/com/shazam/fork/gradle/ForkRunTask.groovy
@@ -75,6 +75,8 @@ class ForkRunTask extends DefaultTask implements VerificationTask {
 
     boolean autoGrantPermissions;
 
+    String excludedAnnotation
+
     @TaskAction
     void runFork() {
         LOG.info("Run instrumentation tests $instrumentationApk for app $applicationApk")
@@ -99,6 +101,7 @@ class ForkRunTask extends DefaultTask implements VerificationTask {
                 .withCoverageEnabled(isCoverageEnabled)
                 .withPoolingStrategy(poolingStrategy)
                 .withAutoGrantPermissions(autoGrantPermissions)
+                .withExcludedAnnotation(excludedAnnotation)
                 .build();
 
         boolean success = new Fork(configuration).run()

--- a/fork-runner/src/main/java/com/shazam/fork/Configuration.java
+++ b/fork-runner/src/main/java/com/shazam/fork/Configuration.java
@@ -54,6 +54,7 @@ public class Configuration {
     private final boolean isCoverageEnabled;
     private final PoolingStrategy poolingStrategy;
     private final boolean autoGrantPermissions;
+    private final String excludedAnnotation;
 
     private Configuration(Builder builder) {
         androidSdk = builder.androidSdk;
@@ -76,6 +77,7 @@ public class Configuration {
         isCoverageEnabled = builder.isCoverageEnabled;
         poolingStrategy = builder.poolingStrategy;
         autoGrantPermissions = builder.autoGrantPermissions;
+        this.excludedAnnotation = builder.excludedAnnotation;
     }
 
     @Nonnull
@@ -171,6 +173,10 @@ public class Configuration {
         return autoGrantPermissions;
     }
 
+    public String getExcludedAnnotation() {
+        return excludedAnnotation;
+    }
+
     public static class Builder {
         private File androidSdk;
         private File applicationApk;
@@ -192,6 +198,7 @@ public class Configuration {
         private boolean isCoverageEnabled;
         private PoolingStrategy poolingStrategy;
         private boolean autoGrantPermissions;
+        private String excludedAnnotation;
 
         public static Builder configuration() {
             return new Builder();
@@ -279,6 +286,11 @@ public class Configuration {
 
         public Builder withAutoGrantPermissions(boolean autoGrantPermissions) {
             this.autoGrantPermissions = autoGrantPermissions;
+            return this;
+        }
+
+        public Builder withExcludedAnnotation(String excludedAnnotation) {
+            this.excludedAnnotation = excludedAnnotation;
             return this;
         }
 

--- a/fork-runner/src/main/java/com/shazam/fork/ForkCli.java
+++ b/fork-runner/src/main/java/com/shazam/fork/ForkCli.java
@@ -99,6 +99,7 @@ public class ForkCli {
                     .withCoverageEnabled(forkConfiguration.isCoverageEnabled)
                     .withPoolingStrategy(forkConfiguration.poolingStrategy)
                     .withAutoGrantPermissions(forkConfiguration.autoGrantPermissions)
+                    .withExcludedAnnotation(forkConfiguration.excludedAnnotation)
                     .build();
 
             Fork fork = new Fork(configuration);

--- a/fork-runner/src/main/java/com/shazam/fork/ForkConfiguration.java
+++ b/fork-runner/src/main/java/com/shazam/fork/ForkConfiguration.java
@@ -94,6 +94,11 @@ public class ForkConfiguration {
      */
     public boolean autoGrantPermissions = true;
 
+    /**
+     * Filter test run to tests without given annotation
+     */
+    public String excludedAnnotation;
+
     public void poolingStrategy(Closure<?> poolingStrategyClosure) {
         poolingStrategy = new PoolingStrategy();
         poolingStrategyClosure.setDelegate(poolingStrategy);

--- a/fork-runner/src/main/java/com/shazam/fork/runner/TestRun.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/TestRun.java
@@ -11,6 +11,7 @@ package com.shazam.fork.runner;
 
 import com.android.ddmlib.*;
 import com.android.ddmlib.testrunner.*;
+import com.google.common.base.Strings;
 import com.shazam.fork.model.TestCaseEvent;
 import com.shazam.fork.system.io.RemoteFileManager;
 
@@ -57,6 +58,13 @@ class TestRun {
             runner.setCoverage(true);
             runner.addInstrumentationArg("coverageFile", RemoteFileManager.getCoverageFileName(testClassName));
         }
+		String excludedAnnotation = testRunParameters.getExcludedAnnotation();
+		if (!Strings.isNullOrEmpty(excludedAnnotation)) {
+			logger.info("Tests annotated with {} will be excluded", excludedAnnotation);
+			runner.addInstrumentationArg("notAnnotation", excludedAnnotation);
+		} else {
+			logger.info("No excluding any test based on annotations");
+		}
 
 		try {
 			runner.run(testRunListeners);

--- a/fork-runner/src/main/java/com/shazam/fork/runner/TestRunFactory.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/TestRunFactory.java
@@ -43,6 +43,7 @@ public class TestRunFactory {
                 .withTestSize(configuration.getTestSize())
                 .withTestOutputTimeout((int) configuration.getTestOutputTimeout())
                 .withCoverageEnabled(configuration.isCoverageEnabled())
+                .withExcludedAnnotation(configuration.getExcludedAnnotation())
                 .build();
 
         List<ITestRunListener> testRunListeners = testRunListenersFactory.createTestListeners(

--- a/fork-runner/src/main/java/com/shazam/fork/runner/TestRunParameters.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/TestRunParameters.java
@@ -26,6 +26,7 @@ public class TestRunParameters {
 	private final IRemoteAndroidTestRunner.TestSize testSize;
 	private final int testOutputTimeout;
 	private final IDevice deviceInterface;
+	private final String excludedAnnotation;
 
 	public TestCaseEvent getTest() {
 		return test;
@@ -56,6 +57,10 @@ public class TestRunParameters {
 		return isCoverageEnabled;
 	}
 
+	public String getExcludedAnnotation() {
+		return excludedAnnotation;
+	}
+
 	public static class Builder {
 		private TestCaseEvent test;
 		private String testPackage;
@@ -64,6 +69,7 @@ public class TestRunParameters {
 		private IRemoteAndroidTestRunner.TestSize testSize;
 		private IDevice deviceInterface;
 		private int testOutputTimeout;
+		private String excludedAnnotation;
 
 		public static Builder testRunParameters() {
 			return new Builder();
@@ -104,6 +110,11 @@ public class TestRunParameters {
 			return this;
 		}
 
+		public Builder withExcludedAnnotation(String excludedAnnotation) {
+			this.excludedAnnotation = excludedAnnotation;
+			return this;
+		}
+
 		public TestRunParameters build() {
 			return new TestRunParameters(this);
 		}
@@ -117,5 +128,6 @@ public class TestRunParameters {
 		testOutputTimeout = builder.testOutputTimeout;
 		deviceInterface = builder.deviceInterface;
 		isCoverageEnabled = builder.isCoverageEnabled;
+		this.excludedAnnotation = builder.excludedAnnotation;
 	}
 }


### PR DESCRIPTION
Adding a way to exclude some tests based on annotations. This is used at William Hill to exclude some tests on the plan that is triggered after a merge request