### PR TITLE
Properly terminate ADB in Fork if all tests passed

### DIFF
--- a/fork-runner/src/main/java/com/shazam/fork/Fork.java
+++ b/fork-runner/src/main/java/com/shazam/fork/Fork.java
@@ -19,6 +19,7 @@ import java.io.File;
 
 import static com.shazam.fork.injector.ConfigurationInjector.setConfiguration;
 import static com.shazam.fork.injector.ForkRunnerInjector.forkRunner;
+import static com.shazam.fork.injector.system.AdbInjector.adb;
 import static com.shazam.fork.utils.Utils.millisSinceNanoTime;
 import static java.lang.System.nanoTime;
 import static org.apache.commons.io.FileUtils.deleteDirectory;
@@ -49,6 +50,7 @@ public final class Fork {
 		} finally {
             long duration = millisSinceNanoTime(startOfTestsMs);
             logger.info(formatPeriod(0, duration, "'Total time taken:' H 'hours' m 'minutes' s 'seconds'"));
+            adb().terminate();
 		}
 	}
 }


### PR DESCRIPTION
Happens on Windows 7, due to ADB holding I/O with device , runner just hangs in working state