### PR TITLE
Upgrage the Gradle plugin to the stable 3.0.0 version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ task wrapper(type: Wrapper) {
 ext.sourceCompatibility = JavaVersion.VERSION_1_8
 ext.targetCompatibility = JavaVersion.VERSION_1_8
 
-ext.androidPlugin = '3.0.0-beta5'
+ext.androidPlugin = '3.0.0'
 
 def repos = {
     mavenLocal()

--- a/fork-common-test-dex/build.gradle
+++ b/fork-common-test-dex/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:3.0.0-beta5"
+        classpath "com.android.tools.build:gradle:$androidPlugin"
         
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
If an Android project is using the stable 3.0.0, currently there'll be an issue between the stable and the beta version.