### PR TITLE
Fix double counting of fatal failures

### DIFF
--- a/fork-runner/src/main/java/com/shazam/fork/ForkRunner.java
+++ b/fork-runner/src/main/java/com/shazam/fork/ForkRunner.java
@@ -81,9 +81,9 @@ public class ForkRunner {
                 reportMissingTests(aggregatedTestResult);
                 System.out.println("Scheduling their re-execution");
 
-                Collection<TestCaseEvent> testsToExecute =
+                Collection<TestCaseEvent> fatalCrashedTestCases =
                         findFatalCrashedTestCases(testCases, aggregatedTestResult.getFatalCrashedTests());
-                executeTests(poolExecutor, pools, testsToExecute);
+                executeTests(poolExecutor, pools, fatalCrashedTestCases);
 
                 aggregatedTestResult = aggregator.aggregateTestResults(pools, testCases);
 

--- a/fork-runner/src/main/java/com/shazam/fork/runner/OverallProgressReporter.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/OverallProgressReporter.java
@@ -72,10 +72,19 @@ public class OverallProgressReporter implements ProgressReporter {
     }
 
     @Override
-    public int getFailures() {
+    public int getTestFailures() {
         int sum = 0;
         for (PoolProgressTracker value : poolProgressTrackers.values()) {
             sum += value.getNumberOfFailedTests();
+        }
+        return sum;
+    }
+
+    @Override
+    public int getTestRunFailures() {
+        int sum = 0;
+        for (PoolProgressTracker value : poolProgressTrackers.values()) {
+            sum += value.getNumberOfFailedTestRuns();
         }
         return sum;
     }
@@ -137,8 +146,9 @@ public class OverallProgressReporter implements ProgressReporter {
         private void log(int testCaseFailures, boolean singleTestAllowed, boolean result) {
             logBuilder.setLength(0); //clean up.
             logBuilder.append("Retry requested ")
-                    .append(result ? " and allowed. " : " but not allowed. ")
-                    .append("Total retry left :").append(totalAllowedRetryLeft.get())
+                    .append(result ? "and allowed. " : "but not allowed. ")
+                    .append("Total retry left: ")
+                    .append(totalAllowedRetryLeft.get())
                     .append(" and Single Test case retry left: ")
                     .append(singleTestAllowed ? maxRetryPerTestCaseQuota - testCaseFailures : 0);
             logger.debug(logBuilder.toString());

--- a/fork-runner/src/main/java/com/shazam/fork/runner/PoolProgressTracker.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/PoolProgressTracker.java
@@ -15,9 +15,13 @@ public interface PoolProgressTracker {
 
     void failedTest();
 
+    void failedTestRun();
+
     void trackTestEnqueuedAgain();
 
     float getProgress();
 
     int getNumberOfFailedTests();
+
+    int getNumberOfFailedTestRuns();
 }

--- a/fork-runner/src/main/java/com/shazam/fork/runner/PoolProgressTrackerImpl.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/PoolProgressTrackerImpl.java
@@ -15,6 +15,7 @@ public class PoolProgressTrackerImpl implements PoolProgressTracker {
     private final int totalTests;
     private int failedTests;
     private int completedTests;
+    private int failedTestRuns;
 
     public PoolProgressTrackerImpl(int totalTests) {
         this.totalTests = totalTests;
@@ -31,6 +32,11 @@ public class PoolProgressTrackerImpl implements PoolProgressTracker {
     }
 
     @Override
+    public void failedTestRun() {
+        failedTestRuns++;
+    }
+
+    @Override
     public void trackTestEnqueuedAgain() {
         completedTests--;
         failedTests--;
@@ -44,5 +50,10 @@ public class PoolProgressTrackerImpl implements PoolProgressTracker {
     @Override
     public int getNumberOfFailedTests() {
         return failedTests;
+    }
+
+    @Override
+    public int getNumberOfFailedTestRuns() {
+        return failedTestRuns;
     }
 }

--- a/fork-runner/src/main/java/com/shazam/fork/runner/ProgressReporter.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/ProgressReporter.java
@@ -30,7 +30,9 @@ public interface ProgressReporter {
      */
     long millisSinceTestsStarted();
 
-    int getFailures();
+    int getTestFailures();
+
+    int getTestRunFailures();
 
     float getProgress();
 

--- a/fork-runner/src/main/java/com/shazam/fork/runner/listeners/ConsoleLoggingTestRunListener.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/listeners/ConsoleLoggingTestRunListener.java
@@ -45,14 +45,14 @@ class ConsoleLoggingTestRunListener extends NoOpITestRunListener {
 
     @Override
     public void testStarted(TestIdentifier test) {
-        System.out.println(format("%s %s %s %s [%s] %s", runningTime(), progress(), failures(), modelName,
-                serial, testCase(test)));
+        System.out.println(format("%s %s %s %s %s [%s] %s", runningTime(), progress(), failures(),
+                runFailures(), modelName, serial, testCase(test)));
     }
 
     @Override
     public void testFailed(TestIdentifier test, String trace) {
-        System.out.println(format("%s %s %s %s [%s] Failed %s\n %s", runningTime(), progress(), failures(), modelName,
-                serial, testCase(test), trace));
+        System.out.println(format("%s %s %s %s %s [%s] Failed %s\n %s", runningTime(), progress(),
+                failures(), runFailures(), modelName, serial, testCase(test), trace));
     }
 
     @Override
@@ -68,14 +68,14 @@ class ConsoleLoggingTestRunListener extends NoOpITestRunListener {
 
     @Override
     public void testRunFailed(String errorMessage) {
-        System.out.println(format("%s %s %s %s [%s] Test run failed\n%s", runningTime(), progress(), failures(),
-                modelName, serial, errorMessage));
+        System.out.println(format("%s %s %s %s %s [%s] Test run failed\n%s", runningTime(),
+                progress(), failures(), runFailures(), modelName, serial, errorMessage));
     }
 
     @Override
     public void testRunStopped(long elapsedTime) {
-        System.out.println(format("%s %s %s %s [%s] Test run stopped after %s ms", runningTime(), progress(),
-                failures(), modelName, serial, elapsedTime));
+        System.out.println(format("%s %s %s %s %s [%s] Test run stopped after %s ms", runningTime(),
+                progress(), failures(), runFailures(), modelName, serial, elapsedTime));
     }
 
     private String runningTime() {
@@ -92,6 +92,10 @@ class ConsoleLoggingTestRunListener extends NoOpITestRunListener {
     }
 
     private int failures() {
-        return progressReporter.getFailures();
+        return progressReporter.getTestFailures();
+    }
+
+    private int runFailures() {
+        return progressReporter.getTestRunFailures();
     }
 }

--- a/fork-runner/src/main/java/com/shazam/fork/runner/listeners/ProgressTestRunListener.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/listeners/ProgressTestRunListener.java
@@ -19,7 +19,6 @@ import com.shazam.fork.runner.ProgressReporter;
 import java.util.Map;
 
 class ProgressTestRunListener implements ITestRunListener {
-
     private final PoolProgressTracker poolProgressTracker;
 
     ProgressTestRunListener(Pool pool, ProgressReporter progressReporter) {
@@ -58,7 +57,7 @@ class ProgressTestRunListener implements ITestRunListener {
 
     @Override
     public void testRunFailed(String errorMessage) {
-        poolProgressTracker.failedTest();
+        poolProgressTracker.failedTestRun();
     }
 
     @Override

--- a/fork-runner/src/test/java/com/shazam/fork/runner/FakeProgressReporter.java
+++ b/fork-runner/src/test/java/com/shazam/fork/runner/FakeProgressReporter.java
@@ -64,7 +64,12 @@ public final class FakeProgressReporter implements ProgressReporter {
     }
 
     @Override
-    public int getFailures() {
+    public int getTestFailures() {
+        return 0;
+    }
+
+    @Override
+    public int getTestRunFailures() {
         return 0;
     }
 


### PR DESCRIPTION
Fork was keeping wrong counts if a test was crashing as both testFailed and testRunFailed were being triggered but the code assumed only one would be. 

The run results were correct as they are not tied to the counts but the reports themselves. 