### PR TITLE
Fix negative test counting of test Runs

### DIFF
--- a/fork-runner/src/main/java/com/shazam/fork/runner/TestRunFactory.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/TestRunFactory.java
@@ -10,9 +10,12 @@
 
 package com.shazam.fork.runner;
 
+import com.android.annotations.NonNull;
 import com.android.ddmlib.testrunner.ITestRunListener;
 import com.shazam.fork.Configuration;
-import com.shazam.fork.model.*;
+import com.shazam.fork.model.Device;
+import com.shazam.fork.model.Pool;
+import com.shazam.fork.model.TestCaseEvent;
 import com.shazam.fork.runner.listeners.TestRunListenersFactory;
 
 import java.util.List;
@@ -31,7 +34,7 @@ public class TestRunFactory {
         this.testRunListenersFactory = testRunListenersFactory;
     }
 
-    public TestRun createTestRun(TestCaseEvent testCase,
+    public TestRun createTestRun(@NonNull TestCaseEvent testCase,
                                  Device device,
                                  Pool pool,
                                  ProgressReporter progressReporter,

--- a/fork-runner/src/main/java/com/shazam/fork/runner/listeners/ForkXmlTestRunListener.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/listeners/ForkXmlTestRunListener.java
@@ -12,6 +12,7 @@
  */
 package com.shazam.fork.runner.listeners;
 
+import com.android.annotations.NonNull;
 import com.android.ddmlib.testrunner.TestIdentifier;
 import com.android.ddmlib.testrunner.XmlTestRunListener;
 import com.google.common.collect.ImmutableMap;
@@ -22,10 +23,9 @@ import com.shazam.fork.runner.ProgressReporter;
 import com.shazam.fork.system.io.FileManager;
 import com.shazam.fork.system.io.FileType;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.util.Map;
-
-import javax.annotation.Nonnull;
 
 import static com.shazam.fork.summary.TestResult.SUMMARY_KEY_TOTAL_FAILURE_COUNT;
 
@@ -34,6 +34,7 @@ public class ForkXmlTestRunListener extends XmlTestRunListener {
     private final FileManager fileManager;
     private final Pool pool;
     private final Device device;
+    @NonNull
     private final TestCaseEvent testCase;
 
     @Nonnull
@@ -73,9 +74,7 @@ public class ForkXmlTestRunListener extends XmlTestRunListener {
                 mapBuilder.put(SUMMARY_KEY_TOTAL_FAILURE_COUNT, Integer.toString(testFailuresCount));
             }
         }
-        if (testCase != null) {
-            mapBuilder.putAll(testCase.getProperties());
-        }
+        mapBuilder.putAll(testCase.getProperties()); // <--
         return mapBuilder.build();
     }
 }

--- a/fork-runner/src/main/java/com/shazam/fork/runner/listeners/TestRunListenersFactory.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/listeners/TestRunListenersFactory.java
@@ -10,6 +10,7 @@
 
 package com.shazam.fork.runner.listeners;
 
+import com.android.annotations.NonNull;
 import com.android.ddmlib.testrunner.ITestRunListener;
 import com.google.gson.Gson;
 import com.shazam.fork.Configuration;
@@ -43,7 +44,7 @@ public class TestRunListenersFactory {
         this.gson = gson;
     }
 
-    public List<ITestRunListener> createTestListeners(TestCaseEvent testCase,
+    public List<ITestRunListener> createTestListeners(@NonNull TestCaseEvent testCase,
                                                       Device device,
                                                       Pool pool,
                                                       ProgressReporter progressReporter,
@@ -74,7 +75,7 @@ public class TestRunListenersFactory {
                                                              File output,
                                                              Pool pool,
                                                              Device device,
-                                                             TestCaseEvent testCase,
+                                                             @NonNull TestCaseEvent testCase,
                                                              ProgressReporter progressReporter) {
         ForkXmlTestRunListener xmlTestRunListener = new ForkXmlTestRunListener(fileManager, pool, device, testCase, progressReporter);
         xmlTestRunListener.setReportDir(output);

--- a/fork-runner/src/test/java/com/shazam/fork/runner/listeners/RetryListenerTest.java
+++ b/fork-runner/src/test/java/com/shazam/fork/runner/listeners/RetryListenerTest.java
@@ -39,7 +39,7 @@ public class RetryListenerTest {
     private final TestCaseEvent fatalCrashedTestCaseEvent = TestCaseEvent.from(fatalCrashedTest);
 
     @Test
-    public void reschedulesTestIfTestRunFailedAndDeleteTraceFiles() {
+    public void reschedulesTestAndDeletesTraceFilesWhenRunFailed() {
         RetryListener retryListener =
                 new RetryListener(pool, device, mockFailedTestScheduler, mockDeviceTestFilesCleaner);
 
@@ -51,13 +51,13 @@ public class RetryListenerTest {
         }});
 
         TestPipelineEmulator emulator = testPipelineEmulator()
-                .withTestRunFailed("fatal error")
+                .withTestFailed("assert exception")
                 .build();
         emulator.emulateFor(retryListener, fatalCrashedTest);
     }
 
     @Test
-    public void doesNotDeleteTraceFilesIfCannotRescheduleTestAfterTestRunFailed() {
+    public void doesNotDeleteTraceFilesIfCannotRescheduleTestWhenRunFailed() {
         RetryListener retryListener =
                 new RetryListener(pool, device, mockFailedTestScheduler, mockDeviceTestFilesCleaner);
 
@@ -69,7 +69,7 @@ public class RetryListenerTest {
         }});
 
         TestPipelineEmulator emulator = testPipelineEmulator()
-                .withTestRunFailed("fatal error")
+                .withTestFailed("assert exception")
                 .build();
         emulator.emulateFor(retryListener, fatalCrashedTest);
     }
@@ -85,6 +85,22 @@ public class RetryListenerTest {
 
         TestPipelineEmulator emulator = testPipelineEmulator()
                 .withTestFailed("assert exception")
+                .withTestRunFailed("fatal error")
+                .build();
+        emulator.emulateFor(retryListener, fatalCrashedTest);
+    }
+
+    @Test
+    public void doesNotRescheduleTestWhenTestRunFailsWithoutCrash() {
+        RetryListener retryListener =
+                new RetryListener(pool, device, mockFailedTestScheduler, fakeDeviceTestFilesCleaner);
+
+        mockery.checking(new Expectations() {{
+            never(mockFailedTestScheduler);
+            never(mockDeviceTestFilesCleaner);
+        }});
+
+        TestPipelineEmulator emulator = testPipelineEmulator()
                 .withTestRunFailed("fatal error")
                 .build();
         emulator.emulateFor(retryListener, fatalCrashedTest);


### PR DESCRIPTION
Fork would produce wrong test counts in the situation of a Test Run failure without even managed to run any tests in between because of a fatal error. This was caused by the fact that we reduce the number of runs count as soon as we schedule them, causing us to reach negative numbers.

This PR ensures that the Test Run finished unexpectedly before rescheduling, and as a result fixing the test counts as well. 