### PR TITLE
http to https for all fonts requests in templates

### DIFF
--- a/fork-reporter/src/main/resources/templates/index.html
+++ b/fork-reporter/src/main/resources/templates/index.html
@@ -13,7 +13,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Fork History</title>
-        <link href="http://fonts.googleapis.com/css?family=Roboto:regular,medium,thin,italic,mediumitalic,bold" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css?family=Roboto:regular,medium,thin,italic,mediumitalic,bold" rel="stylesheet">
         <link href="static/fork-history.css" rel="stylesheet">
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
         <script type="text/javascript">

--- a/fork-reporter/src/main/resources/templates/pool.html
+++ b/fork-reporter/src/main/resources/templates/pool.html
@@ -13,7 +13,7 @@
     <head>
         <meta charset="utf-8">
         <title>All Sw0 Up</title>
-        <link href="http://fonts.googleapis.com/css?family=Roboto:regular,medium,thin,italic,mediumitalic,bold" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css?family=Roboto:regular,medium,thin,italic,mediumitalic,bold" rel="stylesheet">
         <link href="../static/pool-flakiness.css" rel="stylesheet">
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
         <script type="text/javascript">

--- a/fork-runner/src/main/resources/forkpages/index.html
+++ b/fork-runner/src/main/resources/forkpages/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Fork Execution</title>
-        <link href="http://fonts.googleapis.com/css?family=Roboto:regular,medium,thin,italic,mediumitalic,bold" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css?family=Roboto:regular,medium,thin,italic,mediumitalic,bold" rel="stylesheet">
         <link href="static/bootstrap.min.css" rel="stylesheet">
         <link href="static/bootstrap-responsive.min.css" rel="stylesheet">
         <link href="static/spoon.css" rel="stylesheet">

--- a/fork-runner/src/main/resources/forkpages/pool.html
+++ b/fork-runner/src/main/resources/forkpages/pool.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Fork Execution</title>
-    <link href="http://fonts.googleapis.com/css?family=Roboto:regular,medium,thin,italic,mediumitalic,bold" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Roboto:regular,medium,thin,italic,mediumitalic,bold" rel="stylesheet">
     <link href="../static/bootstrap.min.css" rel="stylesheet">
     <link href="../static/bootstrap-responsive.min.css" rel="stylesheet">
     <link href="../static/spoon.css" rel="stylesheet">

--- a/fork-runner/src/main/resources/forkpages/pooltest.html
+++ b/fork-runner/src/main/resources/forkpages/pooltest.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Fork Execution</title>
-        <link href="http://fonts.googleapis.com/css?family=Roboto:regular,medium,thin,italic,mediumitalic,bold" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css?family=Roboto:regular,medium,thin,italic,mediumitalic,bold" rel="stylesheet">
         <link href="../../static/bootstrap.min.css" rel="stylesheet">
         <link href="../../static/bootstrap-responsive.min.css" rel="stylesheet">
         <link href="../../static/spoon.css" rel="stylesheet">


### PR DESCRIPTION
Changed `http` to `https` for all fonts requests in report templates, this can help to eliminate some console errors when publish reports on CI (Jenkins)