### PR TITLE
Passes the current TestCase into the RetryListener in order to maintain the test properties

### DIFF
--- a/fork-common/src/main/java/com/shazam/fork/model/TestCaseEvent.java
+++ b/fork-common/src/main/java/com/shazam/fork/model/TestCaseEvent.java
@@ -16,10 +16,15 @@ import static org.apache.commons.lang3.builder.ToStringBuilder.reflectionToStrin
 import static org.apache.commons.lang3.builder.ToStringStyle.SIMPLE_STYLE;
 
 public class TestCaseEvent {
+    @Nonnull
     private final String testMethod;
+    @Nonnull
     private final String testClass;
+    @Nonnull
     private final boolean isIgnored;
+    @Nonnull
     private final List<String> permissionsToRevoke;
+    @Nonnull
     private final Map<String, String> properties;
 
     private TestCaseEvent(Builder builder) {
@@ -69,21 +74,27 @@ public class TestCaseEvent {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hashCode(this.testMethod, this.testClass);
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        TestCaseEvent that = (TestCaseEvent) o;
+
+        if (isIgnored != that.isIgnored) return false;
+        if (!testMethod.equals(that.testMethod)) return false;
+        if (!testClass.equals(that.testClass)) return false;
+        if (!permissionsToRevoke.equals(that.permissionsToRevoke)) return false;
+        return properties.equals(that.properties);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        final TestCaseEvent other = (TestCaseEvent) obj;
-        return Objects.equal(this.testMethod, other.testMethod)
-                && Objects.equal(this.testClass, other.testClass);
+    public int hashCode() {
+        int result = testMethod.hashCode();
+        result = 31 * result + testClass.hashCode();
+        result = 31 * result + (isIgnored ? 1 : 0);
+        result = 31 * result + permissionsToRevoke.hashCode();
+        result = 31 * result + properties.hashCode();
+        return result;
     }
 
     @Override

--- a/fork-common/src/test/java/com/shazam/fork/model/TestCaseEventBuilderTest.java
+++ b/fork-common/src/test/java/com/shazam/fork/model/TestCaseEventBuilderTest.java
@@ -1,0 +1,57 @@
+package com.shazam.fork.model;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+public class TestCaseEventBuilderTest {
+
+    @Test
+    public void twoObjectsWithEqualParametersShouldAlwaysBeEqual() {
+        HashMap<String, String> properties = new HashMap<>();
+        properties.put("key", "value");
+
+        TestCaseEvent testCaseEventA = new TestCaseEvent.Builder()
+                .withIsIgnored(true)
+                .withTestClass("TestClass")
+                .withTestMethod("testMethod")
+                .withProperties(properties)
+                .build();
+        TestCaseEvent testCaseEventB = new TestCaseEvent.Builder()
+                .withIsIgnored(true)
+                .withTestClass("TestClass")
+                .withTestMethod("testMethod")
+                .withProperties(properties)
+                .build();
+
+        assertThat(testCaseEventA, equalTo(testCaseEventB));
+    }
+
+    @Test
+    public void twoObjectsWithDifferentParametersShouldNotBeEqual() {
+        HashMap<String, String> propertiesA = new HashMap<>();
+        propertiesA.put("key", "value");
+
+        HashMap<String, String> propertiesB = new HashMap<>();
+        propertiesB.put("key2", "value2");
+
+        TestCaseEvent testCaseEventA = new TestCaseEvent.Builder()
+                .withIsIgnored(true)
+                .withTestClass("TestClass")
+                .withTestMethod("testMethod")
+                .withProperties(propertiesA)
+                .build();
+        TestCaseEvent testCaseEventB = new TestCaseEvent.Builder()
+                .withIsIgnored(true)
+                .withTestClass("TestClass")
+                .withTestMethod("testMethod")
+                .withProperties(propertiesB)
+                .build();
+
+        assertThat(testCaseEventA, not(equalTo(testCaseEventB)));
+    }
+}

--- a/fork-runner/src/main/java/com/shazam/fork/device/FileManagerBasedDeviceTestFilesCleaner.java
+++ b/fork-runner/src/main/java/com/shazam/fork/device/FileManagerBasedDeviceTestFilesCleaner.java
@@ -5,11 +5,13 @@ import com.shazam.fork.model.Pool;
 import com.shazam.fork.model.TestCaseEvent;
 import com.shazam.fork.system.io.FileManager;
 import com.shazam.fork.system.io.FileType;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.io.File;
+
+import javax.annotation.Nonnull;
 
 public class FileManagerBasedDeviceTestFilesCleaner implements DeviceTestFilesCleaner {
     private static final Logger logger = LoggerFactory.getLogger(FileManagerBasedDeviceTestFilesCleaner.class);
@@ -28,7 +30,7 @@ public class FileManagerBasedDeviceTestFilesCleaner implements DeviceTestFilesCl
         File file = fileManager.getFile(FileType.TEST, pool, device, testCase);
         boolean isDeleted = file.delete();
         if (!isDeleted) {
-            logger.warn("Failed to delete a file %s", file.getAbsolutePath());
+            logger.warn("Failed to delete a file {}", file.getAbsolutePath());
         }
         return isDeleted;
     }

--- a/fork-runner/src/main/java/com/shazam/fork/runner/listeners/TestRunListenersFactory.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/listeners/TestRunListenersFactory.java
@@ -57,18 +57,19 @@ public class TestRunListenersFactory {
                 new LogCatTestRunListener(gson, fileManager, pool, device),
                 new SlowWarningTestRunListener(),
                 getScreenTraceTestRunListener(fileManager, pool, device),
-                buildRetryListener(device, pool, progressReporter, testCaseEventQueue),
+                buildRetryListener(device, pool, progressReporter, testCaseEventQueue, testCase),
                 getCoverageTestRunListener(configuration, device, fileManager, pool, testCase));
     }
 
     private RetryListener buildRetryListener(Device device,
                                              Pool pool,
                                              ProgressReporter progressReporter,
-                                             Queue<TestCaseEvent> testCaseEventQueue) {
+                                             Queue<TestCaseEvent> testCaseEventQueue,
+                                             TestCaseEvent testCase) {
         ReporterBasedFailedTestScheduler testScheduler =
                 new ReporterBasedFailedTestScheduler(progressReporter, pool, testCaseEventQueue);
         FileManagerBasedDeviceTestFilesCleaner deviceTestFilesCleaner = new FileManagerBasedDeviceTestFilesCleaner(fileManager, pool, device);
-        return new RetryListener(pool, device, testScheduler, deviceTestFilesCleaner);
+        return new RetryListener(pool, device, testScheduler, deviceTestFilesCleaner, testCase);
     }
 
     private ForkXmlTestRunListener getForkXmlTestRunListener(FileManager fileManager,

--- a/fork-runner/src/test/java/com/shazam/fork/runner/listeners/RetryListenerTest.java
+++ b/fork-runner/src/test/java/com/shazam/fork/runner/listeners/RetryListenerTest.java
@@ -39,9 +39,9 @@ public class RetryListenerTest {
     private final TestCaseEvent fatalCrashedTestCaseEvent = TestCaseEvent.from(fatalCrashedTest);
 
     @Test
-    public void reschedulesTestAndDeletesTraceFilesWhenRunFailed() {
+    public void reschedulesTestIfTestRunFailedAndDeleteTraceFiles() {
         RetryListener retryListener =
-                new RetryListener(pool, device, mockFailedTestScheduler, mockDeviceTestFilesCleaner, fatalCrashedTestCaseEvent);
+                new RetryListener(pool, device, mockFailedTestScheduler, mockDeviceTestFilesCleaner,fatalCrashedTestCaseEvent);
 
         mockery.checking(new Expectations() {{
             oneOf(mockFailedTestScheduler).rescheduleTestExecution(fatalCrashedTestCaseEvent);
@@ -51,15 +51,16 @@ public class RetryListenerTest {
         }});
 
         TestPipelineEmulator emulator = testPipelineEmulator()
-                .withTestFailed("assert exception")
+                .withTestRunFailed("fatal error")
                 .build();
         emulator.emulateFor(retryListener, fatalCrashedTest);
     }
 
     @Test
-    public void doesNotDeleteTraceFilesIfCannotRescheduleTestWhenRunFailed() {
+    public void doesNotDeleteTraceFilesIfCannotRescheduleTestAfterTestRunFailed() {
         RetryListener retryListener =
                 new RetryListener(pool, device, mockFailedTestScheduler, mockDeviceTestFilesCleaner, fatalCrashedTestCaseEvent);
+
 
         mockery.checking(new Expectations() {{
             oneOf(mockFailedTestScheduler).rescheduleTestExecution(fatalCrashedTestCaseEvent);
@@ -69,7 +70,7 @@ public class RetryListenerTest {
         }});
 
         TestPipelineEmulator emulator = testPipelineEmulator()
-                .withTestFailed("assert exception")
+                .withTestRunFailed("fatal error")
                 .build();
         emulator.emulateFor(retryListener, fatalCrashedTest);
     }
@@ -85,22 +86,6 @@ public class RetryListenerTest {
 
         TestPipelineEmulator emulator = testPipelineEmulator()
                 .withTestFailed("assert exception")
-                .withTestRunFailed("fatal error")
-                .build();
-        emulator.emulateFor(retryListener, fatalCrashedTest);
-    }
-
-    @Test
-    public void doesNotRescheduleTestWhenTestRunFailsWithoutCrash() {
-        RetryListener retryListener =
-                new RetryListener(pool, device, mockFailedTestScheduler, fakeDeviceTestFilesCleaner, fatalCrashedTestCaseEvent);
-
-        mockery.checking(new Expectations() {{
-            never(mockFailedTestScheduler);
-            never(mockDeviceTestFilesCleaner);
-        }});
-
-        TestPipelineEmulator emulator = testPipelineEmulator()
                 .withTestRunFailed("fatal error")
                 .build();
         emulator.emulateFor(retryListener, fatalCrashedTest);

--- a/fork-runner/src/test/java/com/shazam/fork/runner/listeners/RetryListenerTest.java
+++ b/fork-runner/src/test/java/com/shazam/fork/runner/listeners/RetryListenerTest.java
@@ -41,7 +41,7 @@ public class RetryListenerTest {
     @Test
     public void reschedulesTestAndDeletesTraceFilesWhenRunFailed() {
         RetryListener retryListener =
-                new RetryListener(pool, device, mockFailedTestScheduler, mockDeviceTestFilesCleaner);
+                new RetryListener(pool, device, mockFailedTestScheduler, mockDeviceTestFilesCleaner, fatalCrashedTestCaseEvent);
 
         mockery.checking(new Expectations() {{
             oneOf(mockFailedTestScheduler).rescheduleTestExecution(fatalCrashedTestCaseEvent);
@@ -59,7 +59,7 @@ public class RetryListenerTest {
     @Test
     public void doesNotDeleteTraceFilesIfCannotRescheduleTestWhenRunFailed() {
         RetryListener retryListener =
-                new RetryListener(pool, device, mockFailedTestScheduler, mockDeviceTestFilesCleaner);
+                new RetryListener(pool, device, mockFailedTestScheduler, mockDeviceTestFilesCleaner, fatalCrashedTestCaseEvent);
 
         mockery.checking(new Expectations() {{
             oneOf(mockFailedTestScheduler).rescheduleTestExecution(fatalCrashedTestCaseEvent);
@@ -77,7 +77,7 @@ public class RetryListenerTest {
     @Test
     public void reschedulesTestWhenTestFailsAndThenTestRunCrashes() {
         RetryListener retryListener =
-                new RetryListener(pool, device, mockFailedTestScheduler, fakeDeviceTestFilesCleaner);
+                new RetryListener(pool, device, mockFailedTestScheduler, fakeDeviceTestFilesCleaner, fatalCrashedTestCaseEvent);
 
         mockery.checking(new Expectations() {{
             oneOf(mockFailedTestScheduler).rescheduleTestExecution(fatalCrashedTestCaseEvent);
@@ -93,7 +93,7 @@ public class RetryListenerTest {
     @Test
     public void doesNotRescheduleTestWhenTestRunFailsWithoutCrash() {
         RetryListener retryListener =
-                new RetryListener(pool, device, mockFailedTestScheduler, fakeDeviceTestFilesCleaner);
+                new RetryListener(pool, device, mockFailedTestScheduler, fakeDeviceTestFilesCleaner, fatalCrashedTestCaseEvent);
 
         mockery.checking(new Expectations() {{
             never(mockFailedTestScheduler);


### PR DESCRIPTION
While rescheduling tests (via the RetryListener) we would create a new TestCaseEvent from the Identifier we have. Because of this, the rescheduled test would not contain the initial properties