### PR TITLE
Changes to support custom APK names

### DIFF
--- a/fork-gradle-plugin/src/main/groovy/com/shazam/fork/gradle/ForkPlugin.groovy
+++ b/fork-gradle-plugin/src/main/groovy/com/shazam/fork/gradle/ForkPlugin.groovy
@@ -80,8 +80,12 @@ class ForkPlugin implements Plugin<Project> {
                 autoGrantPermissions = config.autoGrantPermissions
                 ignoreFailures = config.ignoreFailures
                 excludedAnnotation = config.excludedAnnotation
-                instrumentationApk = getApkFileFromPackageAndroidArtifact(variant)
-                applicationApk = getApkFileFromPackageAndroidArtifact(variant.testedVariant as ApkVariant)
+                instrumentationApk = config.instrumentationApkName != null ?
+                        getApkFileWithCustomName(variant, config.instrumentationApkName) :
+                        getApkFileFromPackageAndroidArtifact(variant)
+                applicationApk = config.applicationApkName != null ?
+                        getApkFileWithCustomName(variant.testedVariant as ApkVariant, config.applicationApkName) :
+                        getApkFileFromPackageAndroidArtifact(variant.testedVariant as ApkVariant)
 
                 String baseOutputDir = config.baseOutputDir
                 File outputBase
@@ -96,6 +100,11 @@ class ForkPlugin implements Plugin<Project> {
             forkTask.outputs.upToDateWhen { false }
         }
         return forkTask
+    }
+
+    private static File getApkFileWithCustomName(ApkVariant variant, String name) {
+        PackageAndroidArtifact application = variant.packageApplicationProvider.get()
+        return new File(application.outputDirectory, name)
     }
 
     private static File getApkFileFromPackageAndroidArtifact(ApkVariant variant) {

--- a/fork-runner/src/main/java/com/shazam/fork/ForkConfigurationExtension.java
+++ b/fork-runner/src/main/java/com/shazam/fork/ForkConfigurationExtension.java
@@ -44,6 +44,16 @@ public class ForkConfigurationExtension {
     public String title;
 
     /**
+     * The custom name for the Application APK, if not passed, the regular APK name will be used
+     */
+    public String applicationApkName;
+
+    /**
+     * The custom name for the Instrumentation APK, if not passed, the regular APK name will be used
+     */
+    public String instrumentationApkName;
+
+    /**
      * The subtitle of the final report
      */
     public String subtitle;


### PR DESCRIPTION
In the contex of our app, the name of the generated apk is changed during the build process, so when we try to run the fork commands (using gradle plugin execution mode) it expects for the original names and cannot find the actual apks.

This can be fixed by allowing Fork to look for a custom named apk, which name would be defined in the properties inside build.gradle. If the property is not defined then the usual approach could be used.

Finally, the properties can be defined in the gradle plugin config of the project:

```
applicationApkName = "MyCustomAppName.apk"
instrumentationApkName = "MyCustomInstrumentationName.apk"
```

With this you can support custom apk names without breaking existing fuctionality.