### PR TITLE
Restore "yellow" label for retried test when they have custom properties 

### DIFF
--- a/fork-common/src/main/java/com/shazam/fork/model/TestCaseEvent.java
+++ b/fork-common/src/main/java/com/shazam/fork/model/TestCaseEvent.java
@@ -2,7 +2,6 @@ package com.shazam.fork.model;
 
 import com.android.ddmlib.testrunner.TestIdentifier;
 import com.google.common.base.Objects;
-
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -20,7 +19,7 @@ public class TestCaseEvent {
     private final String testMethod;
     @Nonnull
     private final String testClass;
-    @Nonnull
+
     private final boolean isIgnored;
     @Nonnull
     private final List<String> permissionsToRevoke;
@@ -73,28 +72,30 @@ public class TestCaseEvent {
         return unmodifiableMap(properties);
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        TestCaseEvent that = (TestCaseEvent) o;
-
-        if (isIgnored != that.isIgnored) return false;
-        if (!testMethod.equals(that.testMethod)) return false;
-        if (!testClass.equals(that.testClass)) return false;
-        if (!permissionsToRevoke.equals(that.permissionsToRevoke)) return false;
-        return properties.equals(that.properties);
-    }
-
+    /**
+     * Only testClass and testMethod considered as this class can be synthetized from
+     * @see com.android.ddmlib.testrunner.TestIdentifier that contains only class and method.
+     */
     @Override
     public int hashCode() {
-        int result = testMethod.hashCode();
-        result = 31 * result + testClass.hashCode();
-        result = 31 * result + (isIgnored ? 1 : 0);
-        result = 31 * result + permissionsToRevoke.hashCode();
-        result = 31 * result + properties.hashCode();
-        return result;
+        return Objects.hashCode(this.testMethod, this.testClass);
+    }
+
+    /**
+     * Only testClass and testMethod considered as this class can be synthetized from
+     * @see com.android.ddmlib.testrunner.TestIdentifier that contains only class and method.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final TestCaseEvent other = (TestCaseEvent) obj;
+        return Objects.equal(this.testMethod, other.testMethod)
+                && Objects.equal(this.testClass, other.testClass);
     }
 
     @Override

--- a/fork-common/src/test/java/com/shazam/fork/model/TestCaseEventBuilderTest.java
+++ b/fork-common/src/test/java/com/shazam/fork/model/TestCaseEventBuilderTest.java
@@ -1,57 +1,158 @@
 package com.shazam.fork.model;
 
 import org.junit.Test;
-
 import java.util.HashMap;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class TestCaseEventBuilderTest {
 
     @Test
-    public void twoObjectsWithEqualParametersShouldAlwaysBeEqual() {
-        HashMap<String, String> properties = new HashMap<>();
-        properties.put("key", "value");
-
+    public void testCaseEventsAreEqualWhenTestClassAndTestMethodAreTheSame() {
         TestCaseEvent testCaseEventA = new TestCaseEvent.Builder()
-                .withIsIgnored(true)
-                .withTestClass("TestClass")
+                .withTestClass("testClass")
                 .withTestMethod("testMethod")
-                .withProperties(properties)
-                .build();
-        TestCaseEvent testCaseEventB = new TestCaseEvent.Builder()
                 .withIsIgnored(true)
-                .withTestClass("TestClass")
-                .withTestMethod("testMethod")
-                .withProperties(properties)
+                .withProperties(properties())
                 .build();
 
-        assertThat(testCaseEventA, equalTo(testCaseEventB));
+        TestCaseEvent testCaseEventB = new TestCaseEvent.Builder()
+                .withTestClass("testClass")
+                .withTestMethod("testMethod")
+                .withIsIgnored(false)
+                .withProperties(otherProperties())
+                .build();
+
+        assertEquals(testCaseEventA, testCaseEventB);
     }
 
     @Test
-    public void twoObjectsWithDifferentParametersShouldNotBeEqual() {
-        HashMap<String, String> propertiesA = new HashMap<>();
-        propertiesA.put("key", "value");
-
-        HashMap<String, String> propertiesB = new HashMap<>();
-        propertiesB.put("key2", "value2");
-
+    public void testCaseEventsAreEqualWhenTestClassAndTestMethodAndIgnoreAndPropertiesAreTheSame() {
         TestCaseEvent testCaseEventA = new TestCaseEvent.Builder()
-                .withIsIgnored(true)
-                .withTestClass("TestClass")
+                .withTestClass("testClass")
                 .withTestMethod("testMethod")
-                .withProperties(propertiesA)
-                .build();
-        TestCaseEvent testCaseEventB = new TestCaseEvent.Builder()
                 .withIsIgnored(true)
-                .withTestClass("TestClass")
-                .withTestMethod("testMethod")
-                .withProperties(propertiesB)
+                .withProperties(properties())
                 .build();
 
-        assertThat(testCaseEventA, not(equalTo(testCaseEventB)));
+        TestCaseEvent testCaseEventB = new TestCaseEvent.Builder()
+                .withTestClass("testClass")
+                .withTestMethod("testMethod")
+                .withIsIgnored(true)
+                .withProperties(properties())
+                .build();
+
+        assertEquals(testCaseEventA, testCaseEventB);
+    }
+
+    @Test
+    public void testCaseEventsAreNotEqualWhenTestClassIsNotTheSame() {
+        TestCaseEvent testCaseEventA = new TestCaseEvent.Builder()
+                .withTestClass("testClass")
+                .withTestMethod("testMethod")
+                .build();
+
+        TestCaseEvent testCaseEventB = new TestCaseEvent.Builder()
+                .withTestClass("anothertestClass")
+                .withTestMethod("testMethod")
+                .build();
+
+        assertNotEquals(testCaseEventA, testCaseEventB);
+    }
+
+    @Test
+    public void testCaseEventsAreNotEqualWhenTestMethodIsNotTheSame() {
+        TestCaseEvent testCaseEventA = new TestCaseEvent.Builder()
+                .withTestClass("testClass")
+                .withTestMethod("testMethod")
+                .build();
+
+        TestCaseEvent testCaseEventB = new TestCaseEvent.Builder()
+                .withTestClass("testClass")
+                .withTestMethod("anotherTestMethod")
+                .build();
+
+        assertNotEquals(testCaseEventA, testCaseEventB);
+    }
+
+    @Test
+    public void testCaseEventsHaveSameHashCodeWhenTestClassAndTestMethodAreTheSame() {
+        TestCaseEvent testCaseEventA = new TestCaseEvent.Builder()
+                .withTestClass("testClass")
+                .withTestMethod("testMethod")
+                .withIsIgnored(true)
+                .withProperties(properties())
+                .build();
+
+        TestCaseEvent testCaseEventB = new TestCaseEvent.Builder()
+                .withTestClass("testClass")
+                .withTestMethod("testMethod")
+                .withIsIgnored(false)
+                .withProperties(otherProperties())
+                .build();
+
+        assertEquals(testCaseEventA.hashCode(), testCaseEventB.hashCode());
+    }
+
+    @Test
+    public void testCaseEventsHaveSameHashCodeWhenTestClassAndTestMethodAndIgnoreAndPropertiesAreTheSame() {
+        TestCaseEvent testCaseEventA = new TestCaseEvent.Builder()
+                .withTestClass("testClass")
+                .withTestMethod("testMethod")
+                .withIsIgnored(true)
+                .withProperties(properties())
+                .build();
+
+        TestCaseEvent testCaseEventB = new TestCaseEvent.Builder()
+                .withTestClass("testClass")
+                .withTestMethod("testMethod")
+                .withIsIgnored(true)
+                .withProperties(properties())
+                .build();
+
+        assertEquals(testCaseEventA.hashCode(), testCaseEventB.hashCode());
+    }
+
+    @Test
+    public void testCaseEventsHaveDifferentHashCodeWhenTestClassIsNotTheSame() {
+        TestCaseEvent testCaseEventA = new TestCaseEvent.Builder()
+                .withTestClass("testClass")
+                .withTestMethod("testMethod")
+                .build();
+
+        TestCaseEvent testCaseEventB = new TestCaseEvent.Builder()
+                .withTestClass("anothertestClass")
+                .withTestMethod("TestMethod")
+                .build();
+
+        assertNotEquals(testCaseEventA.hashCode(), testCaseEventB.hashCode());
+    }
+
+    @Test
+    public void testCaseEventsHaveDifferentHashCodeWhenTestMethodIsNotTheSame() {
+        TestCaseEvent testCaseEventA = new TestCaseEvent.Builder()
+                .withTestClass("testClass")
+                .withTestMethod("testMethod")
+                .build();
+
+        TestCaseEvent testCaseEventB = new TestCaseEvent.Builder()
+                .withTestClass("testClass")
+                .withTestMethod("anotherTestMethod")
+                .build();
+
+        assertNotEquals(testCaseEventA.hashCode(), testCaseEventB.hashCode());
+    }
+
+    private HashMap<String, String> properties() {
+        HashMap<String, String> properties = new HashMap<>();
+        properties.put("key", "value");
+        return properties;
+    }
+
+    private HashMap<String, String> otherProperties() {
+        HashMap<String, String> properties = new HashMap<>();
+        properties.put("anotherKey", "anotherValue");
+        return properties;
     }
 }


### PR DESCRIPTION
This addresses a bug that prevents a test to be reported as unstable ("yellow label") in the fork report and flakiness report.

Steps to repro: 
- Add some properties to a test  ( see `com.shazam.fork.TestProperties` ) 
- Enable the "retry" policy (eg. by adding `"totalAllowedRetryQuota": 2 	"retryPerTestCaseQuota":1`)  in the config
- Force the test to fail the first time and to be re-executed (this to simulate some flakiness)

Expected behaviour:
The test test should be re-executed but reported as unstable ("yellow label")

Actual behaviour:
The test is re-executed as expected but *not* reported as unstable 