### PR TITLE
Restore "yellow" label for retried test when they have custom properties

### DIFF
--- a/fork-common/src/main/java/com/shazam/fork/model/TestCaseEvent.java
+++ b/fork-common/src/main/java/com/shazam/fork/model/TestCaseEvent.java
@@ -1,15 +1,14 @@
 package com.shazam.fork.model;
 
 import com.android.ddmlib.testrunner.TestIdentifier;
-import com.google.common.base.Objects;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.shazam.fork.model.TestCaseEvent.Builder.testCaseEvent;
+import javax.annotation.Nonnull;
+
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 import static org.apache.commons.lang3.builder.ToStringBuilder.reflectionToString;
@@ -20,7 +19,7 @@ public class TestCaseEvent {
     private final String testMethod;
     @Nonnull
     private final String testClass;
-    @Nonnull
+
     private final boolean isIgnored;
     @Nonnull
     private final List<String> permissionsToRevoke;
@@ -36,12 +35,8 @@ public class TestCaseEvent {
     }
 
     @Nonnull
-    public static TestCaseEvent from(@Nonnull TestIdentifier testIdentifier) {
-        return testCaseEvent()
-                .withTestClass(testIdentifier.getClassName())
-                .withTestMethod(testIdentifier.getTestName())
-                .withIsIgnored(false)
-                .build();
+    public TestIdentifier toTestIdentifier() {
+        return new TestIdentifier(testClass, testMethod);
     }
 
     @Nonnull

--- a/fork-common/src/test/java/com/shazam/fork/model/TestCaseEventBuilderTest.java
+++ b/fork-common/src/test/java/com/shazam/fork/model/TestCaseEventBuilderTest.java
@@ -1,11 +1,14 @@
 package com.shazam.fork.model;
 
+import com.android.ddmlib.testrunner.TestIdentifier;
+
 import org.junit.Test;
 
 import java.util.HashMap;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class TestCaseEventBuilderTest {
@@ -53,5 +56,27 @@ public class TestCaseEventBuilderTest {
                 .build();
 
         assertThat(testCaseEventA, not(equalTo(testCaseEventB)));
+    }
+
+    @Test
+    public void generatedTestIdentifierHasCorrectClassName() {
+        TestCaseEvent testCaseEvent = new TestCaseEvent.Builder()
+                .withTestClass("TestClass")
+                .withTestMethod("testMethod")
+                .build();
+        TestIdentifier testIdentifier = testCaseEvent.toTestIdentifier();
+
+        assertEquals(testCaseEvent.getTestClass(),testIdentifier.getClassName());
+    }
+
+    @Test
+    public void generatedTestIdentifierHasCorrectTestName() {
+        TestCaseEvent testCaseEvent = new TestCaseEvent.Builder()
+                .withTestClass("TestClass")
+                .withTestMethod("testMethod")
+                .build();
+        TestIdentifier testIdentifier = testCaseEvent.toTestIdentifier();
+
+        assertEquals(testCaseEvent.getTestMethod(),testIdentifier.getTestName());
     }
 }

--- a/fork-runner/src/main/java/com/shazam/fork/device/FileManagerBasedDeviceTestFilesCleaner.java
+++ b/fork-runner/src/main/java/com/shazam/fork/device/FileManagerBasedDeviceTestFilesCleaner.java
@@ -27,7 +27,7 @@ public class FileManagerBasedDeviceTestFilesCleaner implements DeviceTestFilesCl
 
     @Override
     public boolean deleteTraceFiles(@Nonnull TestCaseEvent testCase) {
-        File file = fileManager.getFile(FileType.TEST, pool, device, testCase);
+        File file = fileManager.getFile(FileType.TEST, pool, device, testCase.toTestIdentifier());
         boolean isDeleted = file.delete();
         if (!isDeleted) {
             logger.warn("Failed to delete a file {}", file.getAbsolutePath());

--- a/fork-runner/src/main/java/com/shazam/fork/model/PoolTestCaseAccumulator.java
+++ b/fork-runner/src/main/java/com/shazam/fork/model/PoolTestCaseAccumulator.java
@@ -1,9 +1,11 @@
 package com.shazam.fork.model;
 
+import com.android.ddmlib.testrunner.TestIdentifier;
+
 public interface PoolTestCaseAccumulator {
     void record(Pool pool, TestCaseEvent testCaseEvent);
 
-    int getCount(Pool pool, TestCaseEvent testCaseEvent);
+    int getCount(Pool pool, TestIdentifier testIdentifier);
 
-    int getCount(TestCaseEvent testCaseEvent);
+    int getCount(TestIdentifier testIdentifier);
 }

--- a/fork-runner/src/main/java/com/shazam/fork/model/PoolTestCaseFailureAccumulator.java
+++ b/fork-runner/src/main/java/com/shazam/fork/model/PoolTestCaseFailureAccumulator.java
@@ -10,6 +10,7 @@
 
 package com.shazam.fork.model;
 
+import com.android.ddmlib.testrunner.TestIdentifier;
 import com.google.common.collect.SetMultimap;
 
 import java.util.function.Predicate;
@@ -43,11 +44,11 @@ public class PoolTestCaseFailureAccumulator implements PoolTestCaseAccumulator {
     }
 
     @Override
-    public int getCount(Pool pool, TestCaseEvent testCaseEvent) {
+    public int getCount(Pool pool, TestIdentifier testIdentifier) {
         if (testCaseCounters.containsKey(pool)) {
             synchronized (testCaseCounters) {
                 return testCaseCounters.get(pool).stream()
-                        .filter(isSameTestCase(testCaseEvent))
+                        .filter(isSameTestCase(testIdentifier))
                         .findFirst()
                         .orElse(TestCaseEventCounter.EMPTY)
                         .getCount();
@@ -58,10 +59,10 @@ public class PoolTestCaseFailureAccumulator implements PoolTestCaseAccumulator {
     }
 
     @Override
-    public int getCount(TestCaseEvent testCaseEvent) {
+    public int getCount(TestIdentifier testIdentifier) {
         synchronized (testCaseCounters) {
             return testCaseCounters.values().stream()
-                    .filter(isSameTestCase(testCaseEvent))
+                    .filter(isSameTestCase(testIdentifier))
                     .mapToInt(TestCaseEventCounter::getCount)
                     .sum();
         }
@@ -73,5 +74,9 @@ public class PoolTestCaseFailureAccumulator implements PoolTestCaseAccumulator {
 
     private static Predicate<TestCaseEventCounter> isSameTestCase(TestCaseEvent testCaseEvent) {
         return testCaseEventCounter -> testCaseEventCounter.getTestCaseEvent().equals(testCaseEvent);
+    }
+
+    private static Predicate<TestCaseEventCounter> isSameTestCase(TestIdentifier testIdentifier) {
+        return testCaseEventCounter -> testCaseEventCounter.getTestCaseEvent().toTestIdentifier().equals(testIdentifier);
     }
 }

--- a/fork-runner/src/main/java/com/shazam/fork/runner/OverallProgressReporter.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/OverallProgressReporter.java
@@ -10,6 +10,7 @@
 
 package com.shazam.fork.runner;
 
+import com.android.ddmlib.testrunner.TestIdentifier;
 import com.shazam.fork.model.Pool;
 import com.shazam.fork.model.PoolTestCaseAccumulator;
 import com.shazam.fork.model.TestCaseEvent;
@@ -102,7 +103,8 @@ public class OverallProgressReporter implements ProgressReporter {
     }
 
     public boolean requestRetry(Pool pool, TestCaseEvent testCase) {
-        boolean result = retryWatchdog.requestRetry(failedTestCasesAccumulator.getCount(testCase));
+        int failuresCount = failedTestCasesAccumulator.getCount(testCase.toTestIdentifier());
+        boolean result = retryWatchdog.requestRetry(failuresCount);
         if (result && poolProgressTrackers.containsKey(pool)) {
             poolProgressTrackers.get(pool).trackTestEnqueuedAgain();
         }
@@ -115,8 +117,8 @@ public class OverallProgressReporter implements ProgressReporter {
     }
 
     @Override
-    public int getTestFailuresCount(Pool pool, TestCaseEvent testCase) {
-        return failedTestCasesAccumulator.getCount(pool, testCase);
+    public int getTestFailuresCount(Pool pool, TestIdentifier testIdentifier) {
+        return failedTestCasesAccumulator.getCount(pool, testIdentifier);
     }
 
     private class RetryWatchdog {

--- a/fork-runner/src/main/java/com/shazam/fork/runner/ProgressReporter.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/ProgressReporter.java
@@ -10,6 +10,7 @@
 
 package com.shazam.fork.runner;
 
+import com.android.ddmlib.testrunner.TestIdentifier;
 import com.shazam.fork.model.Pool;
 import com.shazam.fork.model.TestCaseEvent;
 
@@ -40,5 +41,5 @@ public interface ProgressReporter {
 
     void recordFailedTestCase(Pool pool, TestCaseEvent testCase);
 
-    int getTestFailuresCount(Pool pool, TestCaseEvent testCase);
+    int getTestFailuresCount(Pool pool, TestIdentifier testIdentifier);
 }

--- a/fork-runner/src/main/java/com/shazam/fork/runner/listeners/ForkXmlTestRunListener.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/listeners/ForkXmlTestRunListener.java
@@ -69,7 +69,7 @@ public class ForkXmlTestRunListener extends XmlTestRunListener {
         ImmutableMap.Builder<String, String> mapBuilder = ImmutableMap.<String, String>builder()
                 .putAll(super.getPropertiesAttributes());
         if (test != null) {
-            int testFailuresCount = progressReporter.getTestFailuresCount(pool, TestCaseEvent.from(test));
+            int testFailuresCount = progressReporter.getTestFailuresCount(pool, test);
             if (testFailuresCount > 0) {
                 mapBuilder.put(SUMMARY_KEY_TOTAL_FAILURE_COUNT, Integer.toString(testFailuresCount));
             }

--- a/fork-runner/src/main/java/com/shazam/fork/runner/listeners/RetryListener.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/listeners/RetryListener.java
@@ -35,8 +35,8 @@ public class RetryListener extends NoOpITestRunListener {
     @Nonnull
     private final TestCaseEvent runningTestCase;
 
-    private TestCaseEvent startedTest;
-    private TestCaseEvent failedTest;
+    private TestIdentifier startedTest;
+    private TestIdentifier failedTest;
 
     public RetryListener(Pool pool,
                          Device device,
@@ -52,12 +52,12 @@ public class RetryListener extends NoOpITestRunListener {
 
     @Override
     public void testStarted(TestIdentifier test) {
-        startedTest = TestCaseEvent.from(test);
+        startedTest = test;
     }
 
     @Override
     public void testFailed(TestIdentifier test, String trace) {
-        failedTest = TestCaseEvent.from(test);
+        failedTest = test;
     }
 
     @Override

--- a/fork-runner/src/main/java/com/shazam/fork/system/io/FileManager.java
+++ b/fork-runner/src/main/java/com/shazam/fork/system/io/FileManager.java
@@ -38,5 +38,5 @@ public interface FileManager {
     File getFile(@Nonnull FileType fileType,
                  @Nonnull Pool pool,
                  @Nonnull Device device,
-                 @Nonnull TestCaseEvent testCase);
+                 @Nonnull TestIdentifier testIdentifier);
 }

--- a/fork-runner/src/main/java/com/shazam/fork/system/io/ForkFileManager.java
+++ b/fork-runner/src/main/java/com/shazam/fork/system/io/ForkFileManager.java
@@ -34,7 +34,7 @@ public class ForkFileManager implements FileManager {
 
     @Override
     public File createFile(FileType fileType, Pool pool, Device device, TestCaseEvent testCaseEvent) {
-        return createFile(fileType, pool, device, new TestIdentifier(testCaseEvent.getTestClass(), testCaseEvent.getTestMethod()));
+        return createFile(fileType, pool, device, testCaseEvent.toTestIdentifier());
     }
 
     @Override
@@ -52,7 +52,7 @@ public class ForkFileManager implements FileManager {
     public File createFile(FileType fileType, Pool pool, Device device, TestIdentifier testIdentifier) {
         try {
             Path directory = createDirectory(fileType, pool, device);
-            String filename = createFilenameForTest(TestCaseEvent.from(testIdentifier), fileType);
+            String filename = createFilenameForTest(testIdentifier, fileType);
             return createFile(directory, filename);
         } catch (IOException e) {
             throw new CouldNotCreateDirectoryException(e);
@@ -82,7 +82,7 @@ public class ForkFileManager implements FileManager {
 
     @Override
     public File getFile(FileType fileType, String pool, String safeSerial, TestIdentifier testIdentifier) {
-        String filenameForTest = createFilenameForTest(TestCaseEvent.from(testIdentifier), fileType);
+        String filenameForTest = createFilenameForTest(testIdentifier, fileType);
         Path path = get(output.getAbsolutePath(), fileType.getDirectory(), pool, safeSerial, filenameForTest);
         return path.toFile();
     }
@@ -91,8 +91,8 @@ public class ForkFileManager implements FileManager {
     public File getFile(@Nonnull FileType fileType,
                         @Nonnull Pool pool,
                         @Nonnull Device device,
-                        @Nonnull TestCaseEvent testCase) {
-        String filenameForTest = createFilenameForTest(testCase, fileType);
+                        @Nonnull TestIdentifier testIdentifier) {
+        String filenameForTest = createFilenameForTest(testIdentifier, fileType);
         Path path = get(output.getAbsolutePath(),
                 fileType.getDirectory(),
                 pool.getName(),
@@ -113,8 +113,8 @@ public class ForkFileManager implements FileManager {
         return new File(directory.toFile(), filename);
     }
 
-    private String createFilenameForTest(TestCaseEvent testCase, FileType fileType) {
-        return String.format("%s.%s", testCase.getTestFullName(), fileType.getSuffix());
+    private String createFilenameForTest(TestIdentifier testIdentifier, FileType fileType) {
+        return String.format("%s.%s", testIdentifier.toString(), fileType.getSuffix());
     }
 
     private String createFilenameForTest(TestIdentifier testIdentifier, FileType fileType, int sequenceNumber) {

--- a/fork-runner/src/test/java/com/shazam/fork/model/PoolTestCaseFailureAccumulatorTest.java
+++ b/fork-runner/src/test/java/com/shazam/fork/model/PoolTestCaseFailureAccumulatorTest.java
@@ -47,7 +47,7 @@ public class PoolTestCaseFailureAccumulatorTest {
         subject.record(A_POOL, A_TEST_CASE);
         subject.record(A_POOL, A_TEST_CASE);
 
-        int actualCount = subject.getCount(A_TEST_CASE);
+        int actualCount = subject.getCount(A_TEST_CASE.toTestIdentifier());
 
         assertThat(actualCount, equalTo(2));
     }
@@ -57,7 +57,7 @@ public class PoolTestCaseFailureAccumulatorTest {
         subject.record(A_POOL, A_TEST_CASE);
         subject.record(A_POOL, A_TEST_CASE);
 
-        int actualCount = subject.getCount(A_POOL, A_TEST_CASE);
+        int actualCount = subject.getCount(A_POOL, A_TEST_CASE.toTestIdentifier());
 
         assertThat(actualCount, equalTo(2));
     }
@@ -67,7 +67,7 @@ public class PoolTestCaseFailureAccumulatorTest {
         subject.record(A_POOL, A_TEST_CASE);
         subject.record(ANOTHER_POOL, A_TEST_CASE);
 
-        int actualCount = subject.getCount(A_TEST_CASE);
+        int actualCount = subject.getCount(A_TEST_CASE.toTestIdentifier());
 
         assertThat(actualCount, equalTo(2));
     }
@@ -76,7 +76,7 @@ public class PoolTestCaseFailureAccumulatorTest {
     public void shouldNotReturnTestCasesForDifferentPool() {
         subject.record(A_POOL, A_TEST_CASE);
 
-        int actualCountForAnotherDevice = subject.getCount(ANOTHER_POOL, A_TEST_CASE);
+        int actualCountForAnotherDevice = subject.getCount(ANOTHER_POOL, A_TEST_CASE.toTestIdentifier());
 
         assertThat(actualCountForAnotherDevice, equalTo(0));
     }
@@ -86,8 +86,8 @@ public class PoolTestCaseFailureAccumulatorTest {
         subject.record(A_POOL, A_TEST_CASE);
         subject.record(A_POOL, ANOTHER_TEST_CASE);
 
-        int actualCount = subject.getCount(A_POOL, A_TEST_CASE);
-        int anotherActualCount = subject.getCount(A_POOL, ANOTHER_TEST_CASE);
+        int actualCount = subject.getCount(A_POOL, A_TEST_CASE.toTestIdentifier());
+        int anotherActualCount = subject.getCount(A_POOL, ANOTHER_TEST_CASE.toTestIdentifier());
 
         assertThat(actualCount, equalTo(1));
         assertThat(anotherActualCount, equalTo(1));

--- a/fork-runner/src/test/java/com/shazam/fork/runner/FakePoolTestCaseAccumulator.java
+++ b/fork-runner/src/test/java/com/shazam/fork/runner/FakePoolTestCaseAccumulator.java
@@ -1,5 +1,6 @@
 package com.shazam.fork.runner;
 
+import com.android.ddmlib.testrunner.TestIdentifier;
 import com.shazam.fork.model.Pool;
 import com.shazam.fork.model.PoolTestCaseAccumulator;
 import com.shazam.fork.model.TestCaseEvent;
@@ -35,12 +36,12 @@ public class FakePoolTestCaseAccumulator implements PoolTestCaseAccumulator {
     }
 
     @Override
-    public int getCount(Pool pool, TestCaseEvent testCaseEvent) {
+    public int getCount(Pool pool, TestIdentifier testIdentifier) {
         return poolCount;
     }
 
     @Override
-    public int getCount(TestCaseEvent testCaseEvent) {
+    public int getCount(TestIdentifier testIdentifier) {
         return testCaseCount;
     }
 }

--- a/fork-runner/src/test/java/com/shazam/fork/runner/FakeProgressReporter.java
+++ b/fork-runner/src/test/java/com/shazam/fork/runner/FakeProgressReporter.java
@@ -10,6 +10,7 @@
 
 package com.shazam.fork.runner;
 
+import com.android.ddmlib.testrunner.TestIdentifier;
 import com.shazam.fork.model.Pool;
 import com.shazam.fork.model.TestCaseEvent;
 
@@ -89,7 +90,7 @@ public final class FakeProgressReporter implements ProgressReporter {
     }
 
     @Override
-    public int getTestFailuresCount(Pool pool, TestCaseEvent testCase) {
+    public int getTestFailuresCount(Pool pool, TestIdentifier testIdentifier) {
         return 0;
     }
 }

--- a/fork-runner/src/test/java/com/shazam/fork/runner/listeners/RetryListenerTest.java
+++ b/fork-runner/src/test/java/com/shazam/fork/runner/listeners/RetryListenerTest.java
@@ -8,6 +8,7 @@ import com.shazam.fork.model.Pool;
 import com.shazam.fork.model.TestCaseEvent;
 import com.shazam.fork.runner.FailedTestScheduler;
 import com.shazam.fork.util.TestPipelineEmulator;
+
 import org.jmock.Expectations;
 import org.jmock.auto.Mock;
 import org.jmock.integration.junit4.JUnitRuleMockery;
@@ -17,6 +18,7 @@ import org.junit.Test;
 import static com.shazam.fork.device.FakeDeviceTestFilesCleaner.fakeDeviceTestFilesCleaner;
 import static com.shazam.fork.model.Device.Builder.aDevice;
 import static com.shazam.fork.model.Pool.Builder.aDevicePool;
+import static com.shazam.fork.model.TestCaseEvent.Builder.testCaseEvent;
 import static com.shazam.fork.util.TestPipelineEmulator.Builder.testPipelineEmulator;
 
 public class RetryListenerTest {
@@ -36,12 +38,15 @@ public class RetryListenerTest {
             .build();
 
     private final TestIdentifier fatalCrashedTest = new TestIdentifier("com.example.FatalCrashedTest", "testMethod");
-    private final TestCaseEvent fatalCrashedTestCaseEvent = TestCaseEvent.from(fatalCrashedTest);
+    private final TestCaseEvent fatalCrashedTestCaseEvent = testCaseEvent()
+            .withTestClass(fatalCrashedTest.getClassName())
+            .withTestMethod(fatalCrashedTest.getTestName())
+            .build();
 
     @Test
     public void reschedulesTestIfTestRunFailedAndDeleteTraceFiles() {
         RetryListener retryListener =
-                new RetryListener(pool, device, mockFailedTestScheduler, mockDeviceTestFilesCleaner,fatalCrashedTestCaseEvent);
+                new RetryListener(pool, device, mockFailedTestScheduler, mockDeviceTestFilesCleaner, fatalCrashedTestCaseEvent);
 
         mockery.checking(new Expectations() {{
             oneOf(mockFailedTestScheduler).rescheduleTestExecution(fatalCrashedTestCaseEvent);


### PR DESCRIPTION
This addresses a bug that prevents annotated tests to be reported as unstable ("yellow label") in the fork report and flakiness report.

Steps to repro:

Add some properties to a test ( see com.shazam.fork.TestProperties )
Enable the "retry" policy (eg. by adding "totalAllowedRetryQuota": 2 "retryPerTestCaseQuota":1) in the config
Force the test to fail the first time and to be re-executed (this to simulate some flakiness)
Expected behaviour:
The test should be re-executed but reported as unstable ("yellow label")

Actual behaviour:
The test is re-executed as expected but not reported as unstable (it's just marked as green)