### PR TITLE
Fix ignoring test logic.

### DIFF
--- a/fork-runner/src/main/java/com/shazam/fork/ForkRunner.java
+++ b/fork-runner/src/main/java/com/shazam/fork/ForkRunner.java
@@ -74,7 +74,8 @@ public class ForkRunner {
             Collection<TestCaseEvent> testCases = testClassLoader.loadTestSuite();
             summaryGeneratorHook.registerHook(pools, testCases);
 
-            executeTests(poolExecutor, pools, testCases);
+            executeTests(poolExecutor, pools, testCases
+                    .stream().filter(it -> !it.isIgnored()).collect(toList()));
 
             AggregatedTestResult aggregatedTestResult = aggregator.aggregateTestResults(pools, testCases);
             if (!aggregatedTestResult.getFatalCrashedTests().isEmpty()) {


### PR DESCRIPTION
Currently ignored tests still launched by fork and then reported that they are suppresed (ignored).
Fix is pretty simple.